### PR TITLE
Java multiple files

### DIFF
--- a/schema/echo.proto
+++ b/schema/echo.proto
@@ -23,6 +23,7 @@ package google.showcase.v1alpha1;
 
 option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
 option java_package = "com.google.showcase.v1";
+option java_multiple_files = true;
 
 option (google.api.metadata) = {
   product_uri: "https://github.com/googleapis/gapic-showcase"


### PR DESCRIPTION
How about setting the `java_multiple_files` option since it's typically used?