### PR TITLE
Move release script to a go file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,25 +63,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install server
-          command: |
-            go get
-            go install
-            echo "export VERSION=$(gapic-showcase --version)" >> $BASH_ENV
-      - run:
-          name: Cross compile the server binary
-          command: |
-            # This is a windows dependency that is not implicitly got at
-            # the top level go get.
-            go get github.com/inconshreveable/mousetrap
-            go get github.com/mitchellh/gox
-            gox -os="windows linux" -arch="amd64 arm" -output \
-                "dist/gapic-showcase-v1alpha2-${VERSION}-{{.OS}}-{{.Arch}}" \
-                github.com/googleapis/gapic-showcase/
-            gox -os="darwin" -arch="amd64" -output \
-                "dist/gapic-showcase-v1alpha2-${VERSION}-{{.OS}}-{{.Arch}}" \
-                github.com/googleapis/gapic-showcase/
-      - run:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
@@ -90,33 +71,13 @@ jobs:
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/
       - run:
-          name: Get proto dependencies.
+          name: Create release assets
           command: |
-            git clone -b input-contract \
-                https://github.com/googleapis/api-common-protos.git \
-                tmp/api-common-protos
-      - run:
-          name: Stage the showcase protos with it's dependencies.
-          command: |
-            mkdir -p tmp/api-common-protos/google/showcase/v1alpha2
-            cp schema/echo.proto tmp/api-common-protos/google/showcase/v1alpha2/
-      - run:
-          name: Compile the proto descriptor set.
-          command: |
-            protoc --proto_path=tmp/api-common-protos --include_imports \
-                --include_source_info \
-                -o dist/gapic-showcase-v1alpha2-${VERSION}.desc \
-                tmp/api-common-protos/google/showcase/v1alpha2/echo.proto
-      - run:
-          name: Make a tarball of the protos.
-          command: |
-            mkdir tmp/gapic-showcase-v1alpha2-${VERSION}-protos
-            cp -r tmp/api-common-protos/google tmp/gapic-showcase-v1alpha2-${VERSION}-protos
-            cd tmp/ && tar -zcf ../dist/gapic-showcase-v1alpha2-${VERSION}-protos.tar.gz gapic-showcase-v1alpha2-${VERSION}-protos
+            go get ./util/release
+            go run util/release/main.go
       - run:
           name: Attach compiled stuff to the tag.
           command: |
-            ls dist
             go get github.com/tcnksm/ghr
             ghr -t ${GITHUB_TOKEN} \
                 -u ${CIRCLE_PROJECT_USERNAME} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install server
+          command: |
+            go get
+            go install
+            echo "export VERSION=$(gapic-showcase --version)" >> $BASH_ENV
+      - run:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
@@ -72,9 +78,7 @@ jobs:
             mv ~/protoc3/include/* /usr/local/include/
       - run:
           name: Create release assets
-          command: |
-            go get ./util/release
-            go run util/release/main.go
+          command: go run util/release/main.go
       - run:
           name: Attach compiled stuff to the tag.
           command: |
@@ -82,4 +86,5 @@ jobs:
             ghr -t ${GITHUB_TOKEN} \
                 -u ${CIRCLE_PROJECT_USERNAME} \
                 -r ${CIRCLE_PROJECT_REPONAME} \
-                -c ${CIRCLE_SHA1} v${VERSION} ./dist/
+                -c ${CIRCLE_SHA1} \
+                v${VERSION} ./dist/

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -33,20 +33,27 @@ func main() {
 
 func setup() {
 	distDir := filepath.Join(showcaseDir(), "dist")
-	os.RemoveAll(distDir)
+	if err := os.RemoveAll(distDir); err != nil {
+		log.Fatalf("Failed to remove the directory %s: %v", distDir, err)
+	}
 	if err := os.MkdirAll(distDir, 0755); err != nil {
 		log.Fatalf("Failed to make the directory %s: %v", distDir, err)
 	}
 
 	tmpDir := filepath.Join(showcaseDir(), "tmp")
-	os.RemoveAll(tmpDir)
+	if err := os.RemoveAll(tmpDir); err != nil {
+		log.Fatalf("Failed to remove the directory %s: %v", tmpDir, err)
+	}
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
 		log.Fatalf("Failed to make the directory %s: %v", tmpDir, err)
 	}
 }
 
 func teardown() {
-	os.RemoveAll(filepath.Join(showcaseDir(), "tmp"))
+	tmpDir := filepath.Join(showcaseDir(), "tmp")
+	if err := os.RemoveAll(tmpDir); err != nil {
+		log.Fatalf("Failed to remove the directory %s: %v", tmpDir, err)
+	}
 }
 
 func stageProtos() {
@@ -173,7 +180,7 @@ func executeInDir(dir string, args ...string) {
 	}
 }
 
-var sOnce sync.Once = sync.Once{}
+var sOnce sync.Once
 var showcaseDirMemo string
 
 func showcaseDir() string {
@@ -190,7 +197,7 @@ func showcaseDir() string {
 	return showcaseDirMemo
 }
 
-var verOnce sync.Once = sync.Once{}
+var verOnce sync.Once
 var versionMemo string
 
 func version() string {

--- a/util/release/main.go
+++ b/util/release/main.go
@@ -1,0 +1,222 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+func main() {
+	setup()
+	stageProtos()
+	parallelize(compileDescriptors, tarProtos, compileBinaries)
+	teardown()
+}
+
+func setup() {
+	os.Chdir(showcaseDir())
+
+	distDir := filepath.Join(showcaseDir(), "dist")
+	os.RemoveAll(distDir)
+	os.MkdirAll(distDir, 0755)
+
+	tmpDir := filepath.Join(showcaseDir(), "tmp")
+	os.RemoveAll(tmpDir)
+	os.MkdirAll(tmpDir, 0755)
+}
+
+func teardown() {
+	os.RemoveAll(filepath.Join(showcaseDir(), "tmp"))
+}
+
+func stageProtos() {
+	// Get proto dependencies
+	execute(
+		"git",
+		"clone",
+		"-b",
+		"input-contract",
+		"https://github.com/googleapis/api-common-protos.git",
+		filepath.Join(showcaseDir(), "tmp", "api-common-protos"),
+	)
+
+	// Move showcase protos alongside it's dependencies.
+	protoDest := filepath.Join(
+		showcaseDir(),
+		"tmp",
+		"api-common-protos",
+		"google",
+		"showcase",
+		"v1alpha2")
+	os.MkdirAll(protoDest, 0755)
+
+	files, err := filepath.Glob(filepath.Join(showcaseDir(), "schema", "*.proto"))
+	if err != nil {
+		log.Fatal("Error: failed to find protos in " + showcaseDir())
+	}
+
+	for _, f := range files {
+		execute("cp", f, protoDest)
+	}
+}
+
+func compileDescriptors() {
+	// Check if protoc is installed.
+	if err := exec.Command("protoc", "--version").Run(); err != nil {
+		log.Fatal("Error: 'protoc' is expected to be installed on the path.")
+	}
+
+	// Compile protos
+	protoDest := filepath.Join(
+		showcaseDir(),
+		"tmp",
+		"api-common-protos",
+		"google",
+		"showcase",
+		"v1alpha2")
+
+	files, err := filepath.Glob(filepath.Join(protoDest, "*.proto"))
+	if err != nil {
+		log.Fatal("Error: failed to find protos in " + protoDest)
+	}
+	command := []string{
+		"protoc",
+		"--proto_path=" + filepath.Join(showcaseDir(), "tmp", "api-common-protos"),
+		"--include_imports",
+		"--include_source_info",
+		"-o" + filepath.Join(showcaseDir(), "dist", fmt.Sprintf("gapic-showcase-%s.desc", version())),
+	}
+	execute(append(command, files...)...)
+}
+
+func tarProtos() {
+	tmpDir := filepath.Join(showcaseDir(), "tmp")
+	stagingDir := filepath.Join(tmpDir, fmt.Sprintf("gapic-showcase-v1alpha2-%s-protos", version()))
+	output := filepath.Join(showcaseDir(), "dist", fmt.Sprintf("gapic-showcase-v1alpha2-%s-protos.tar.gz", version()))
+
+	os.MkdirAll(stagingDir, 0755)
+	execute("cp", "-r", filepath.Join(tmpDir, "api-common-protos", "google"), stagingDir)
+
+	os.Chdir(tmpDir)
+	defer os.Chdir(showcaseDir())
+	execute("tar", "-zcf", output, fmt.Sprintf("gapic-showcase-v1alpha2-%s-protos", version()))
+}
+
+func compileBinaries() {
+	stagingDir := filepath.Join(showcaseDir(), "tmp", "x")
+	outputDir := filepath.Join(showcaseDir(), "dist")
+	execute("go", "get", "github.com/mitchellh/gox")
+
+	// This is a windows dependency that is not implicitly got since we only get
+	// the linux dependencies
+	execute("go", "get", "github.com/inconshreveable/mousetrap")
+
+	osArchs := []string{
+		"windows/amd64",
+		"linux/amd64",
+		"darwin/amd64",
+		"linux/arm",
+	}
+	for _, osArch := range osArchs {
+		execute(
+			"gox",
+			fmt.Sprintf("-osarch=%s", osArch),
+			"-output",
+			filepath.Join(stagingDir, fmt.Sprintf("gapic-showcase-v1alpha2-%s-{{.OS}}-{{.Arch}}/gapic-showcase", version())),
+			"github.com/googleapis/gapic-showcase")
+	}
+
+	dirs, _ := filepath.Glob(filepath.Join(stagingDir, "*"))
+	for _, dir := range dirs {
+		os.Chdir(dir)
+		// The windows binaries are suffixed with '.exe'. This allows us to create
+		// tarballs of the executables whether or not they contain a suffix.
+		files, _ := filepath.Glob(filepath.Join(dir, "gapic-showcase*"))
+		execute(
+			"tar",
+			"-zcf",
+			filepath.Join(outputDir, filepath.Base(dir)+".tar.gz"),
+			filepath.Base(files[0]))
+	}
+	os.Chdir(showcaseDir())
+}
+
+func execute(args ...string) {
+	log.Print("Executing: ", strings.Join(args, " "))
+	if output, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+		log.Fatalf("%s", output)
+	}
+}
+
+var sDirMu sync.Mutex = sync.Mutex{}
+var showcaseDirMemo string
+
+func showcaseDir() string {
+	sDirMu.Lock()
+	defer sDirMu.Unlock()
+	if showcaseDirMemo != "" {
+		return showcaseDirMemo
+	}
+	gopath := os.Getenv("GOPATH")
+	showcaseDir := filepath.Join(
+		gopath,
+		"src",
+		"github.com",
+		"googleapis",
+		"gapic-showcase")
+	showcaseDirMemo = showcaseDir
+	return showcaseDirMemo
+}
+
+var verMu sync.Mutex = sync.Mutex{}
+var versionMemo string
+
+func version() string {
+	verMu.Lock()
+	defer verMu.Unlock()
+	if versionMemo != "" {
+		return versionMemo
+	}
+	os.Chdir(showcaseDir())
+	execute("go", "get")
+	execute("go", "install")
+	version, err := exec.Command("gapic-showcase", "--version").Output()
+	if err != nil {
+		log.Fatal("Failed getting showcase version")
+	}
+
+	versionMemo = strings.TrimSpace(string(version[:]))
+	return versionMemo
+}
+
+func parallelize(functions ...func()) {
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(len(functions))
+	defer waitGroup.Wait()
+
+	for _, function := range functions {
+		go func(copy func()) {
+			copy()
+			waitGroup.Done()
+		}(function)
+	}
+}


### PR DESCRIPTION
This moves the bulk of the release script to a go file. This also
changes the released binaries to become tarballs. This is for two
specific reasons:

1. By tarballing the executables, it preserves the +x permission on the
file.
1. It allows for simpler binary usage

### New
```
curl -L <link to tar> | sudo tar -zx -- --directory /usr/local/bin/
gapic-showcase start
```

### Old
```
curl -L <link to binary>
chmod u+x binary
mv binary /usr/local/bin/gapic-showcase
gapic-showcase start
```