### PR TITLE
fix flattening config

### DIFF
--- a/schema/echo.proto
+++ b/schema/echo.proto
@@ -91,7 +91,7 @@ service Echo {
       body: "*"
     };
     option (google.api.method_signature) = {
-      fields: ["max_response", "page_size_override"]
+      fields: ["max_response"]
     };
   }
 }


### PR DESCRIPTION
The 0.5 release removed a field from the proto, but left it in the `method_signature` annotation. 