### PR TITLE
Change echo service default_host to localhost, without port

### DIFF
--- a/schema/echo.proto
+++ b/schema/echo.proto
@@ -36,7 +36,7 @@ option (google.api.metadata) = {
 service Echo {
   // This service is meant to only run locally on the port 7469 (keypad digits
   // for "show").
-  option (google.api.default_host) = "localhost:7469";
+  option (google.api.default_host) = "localhost";
 
   // This method simply echos the request. This method is showcases unary rpcs.
   rpc Echo(EchoRequest) returns (EchoResponse) {


### PR DESCRIPTION
Resolves https://github.com/googleapis/gapic-showcase/issues/25

See https://github.com/googleapis/gapic-generator/pull/2346 for gapic-generator CI build using this PR.