### PR TITLE
[chore] Use a multi-stage build to get a smaller image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,32 @@
-FROM golang:1.11-alpine
+FROM golang:1.11-alpine AS builder
 
-# Install git
+# Install git and gcc.
 RUN apk add --no-cache git gcc musl-dev
 
-# Setup directory
+# Setup directory.
 WORKDIR /go/src/github.com/googleapis/gapic-showcase
 COPY . .
 
-# Use go modules.
+# Use go modules, and only compile for Linux.
 ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
 
-# Install showcase
-RUN ["go", "get"]
-RUN ["go", "install"]
+# Install showcase.
+RUN go get
+RUN go build -a \
+  -installsuffix cgo \
+  -ldflags="-w -s" \
+  -o /go/bin/gapic-showcase
+
+# Start a fresh image, and only copy the built binary.
+FROM scratch
+COPY --from=builder /go/bin/gapic-showcase /go/bin/gapic-showcase
 
 # Expose port
 EXPOSE 7469
 
 # Run the server.
-ENTRYPOINT ["gapic-showcase"]
+ENTRYPOINT ["/go/bin/gapic-showcase"]
 CMD ["run"]


### PR DESCRIPTION
The resulting image is 9.3 MB (down from ~600 MB). :-)