### PR TITLE
move docker images to gapic-images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,12 +183,12 @@ jobs:
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
       - run:
           name: Build docker image
-          command: docker build -t gcr.io/gapic-showcase/gapic-showcase .
+          command: docker build -t gcr.io/${GOOGLE_PROJECT_ID}/gapic-showcase .
       - run:
           name: Tag image
-          command: docker tag gcr.io/gapic-showcase/gapic-showcase gcr.io/gapic-showcase/gapic-showcase:${CIRCLE_TAG}
+          command: docker tag gcr.io/${GOOGLE_PROJECT_ID}/gapic-showcase gcr.io/${GOOGLE_PROJECT_ID}/gapic-showcase:${CIRCLE_TAG}
       - run:
           name: Push image
           command: |
-            gcloud docker -- push gcr.io/gapic-showcase/gapic-showcase:latest
-            gcloud docker -- push gcr.io/gapic-showcase/gapic-showcase:${CIRCLE_TAG}
+            gcloud docker -- push gcr.io/${GOOGLE_PROJECT_ID}/gapic-showcase:latest
+            gcloud docker -- push gcr.io/${GOOGLE_PROJECT_ID}/gapic-showcase:${CIRCLE_TAG}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ our [releases](https://github.com/googleapis/gapic-showcase/releases) page.
 ### Installation
 The GAPIC Showcase CLI Tool can be installed using three different mechanisms,
 downloading the compiled binary from our our [releases](https://github.com/googleapis/gapic-showcase/releases)
-page, pulling our released docker image from [google container registry](https://gcr.io/gapic-showcase/gapic-showcase),
+page, pulling our released docker image from [Google Container Registry](https://gcr.io/gapic-images/gapic-showcase),
 or simply by using go commands.
 
 #### Binary Installation
@@ -40,9 +40,9 @@ $ gapic-showcase run
 #### Docker Installation
 ```sh
 $ export GAPIC_SHOWCASE_VERSION=0.0.12
-$ docker pull gcr.io/gapic-showcase/gapic-showcase:${GAPIC_SHOWCASE_VERSION}
+$ docker pull gcr.io/gapic-images/gapic-showcase:${GAPIC_SHOWCASE_VERSION}
 $ docker run --rm -p 7469:7469/tcp -p 7469:7469/udp \
-    gcr.io/gapic-showcase/gapic-showcase:${GAPIC_SHOWCASE_VERSION}
+    gcr.io/gapic-images/gapic-showcase:${GAPIC_SHOWCASE_VERSION}
 > 2018/09/19 02:13:09 Showcase listening on port: :7469
 ```
 


### PR DESCRIPTION
* push image to project configured in CircleCI (changed it to `gapic-images` & added new credentials already)
* update README with new docker image name