### PR TITLE
Fix path templates to start with /

### DIFF
--- a/schema/messaging.proto
+++ b/schema/messaging.proto
@@ -95,7 +95,7 @@ service Messaging {
       post: "/v1alpha3/{parent=rooms/*}/blurbs"
       body: "*"
       additional_bindings: {
-        post: "v1alpha3/{parent=users/*/profile}/blurbs"
+        post: "/v1alpha3/{parent=users/*/profile}/blurbs"
         body: "*"
       }
     };
@@ -108,7 +108,7 @@ service Messaging {
     option (google.api.http) = {
       get: "/v1alpha3/{name=rooms/*/blurbs/*}"
       additional_bindings: {
-        get: "v1alpha3/{name=users/*/profile/blurbs/*}"
+        get: "/v1alpha3/{name=users/*/profile/blurbs/*}"
       }
     };
     option (google.api.method_signature) = "name";
@@ -120,7 +120,7 @@ service Messaging {
       patch: "/v1alpha3/{blurb.name=rooms/*/blurbs/*}"
       body: "*"
       additional_bindings: {
-        patch: "v1alpha3/{blurb.name=users/*/profile/blurbs/*}"
+        patch: "/v1alpha3/{blurb.name=users/*/profile/blurbs/*}"
         body: "*"
       }
     };
@@ -131,7 +131,7 @@ service Messaging {
     option (google.api.http) = {
       delete: "/v1alpha3/{name=rooms/*/blurbs/*}"
       additional_bindings: {
-        delete: "v1alpha3/{name=users/*/profile/blurbs/*}"
+        delete: "/v1alpha3/{name=users/*/profile/blurbs/*}"
       }
     };
     option (google.api.method_signature) = "name";
@@ -143,7 +143,7 @@ service Messaging {
     option (google.api.http) = {
       get: "/v1alpha3/{parent=rooms/*}/blurbs"
       additional_bindings: {
-        get: "v1alpha3/{parent=users/*/profile}/blurbs}"
+        get: "/v1alpha3/{parent=users/*/profile}/blurbs}"
       }
     };
     option (google.api.method_signature) = "parent";
@@ -157,7 +157,7 @@ service Messaging {
       post: "/v1alpha3/{parent=rooms/-}/blurbs:search"
       body: "*"
       additional_bindings: {
-        post: "v1alpha3/{parent=users/-/profile}/blurbs:search"
+        post: "/v1alpha3/{parent=users/-/profile}/blurbs:search"
       }
     };
     option (google.longrunning.operation_info) = {
@@ -174,7 +174,7 @@ service Messaging {
       post: "/v1alpha3/{name=rooms/*}/blurbs:stream"
       body: "*"
       additional_bindings: {
-        post: "v1alpha3/{parent=users/*/profile}/blurbs:stream"
+        post: "/v1alpha3/{parent=users/*/profile}/blurbs:stream"
         body: "*"
       }
     };
@@ -187,7 +187,7 @@ service Messaging {
       post: "/v1alpha3/{parent=rooms/*}/blurbs:send"
       body: "*"
       additional_bindings: {
-        post: "v1alpha3/{parent=users/*/profile}/blurbs:send"
+        post: "/v1alpha3/{parent=users/*/profile}/blurbs:send"
         body: "*"
       }
     };


### PR DESCRIPTION
gapic-generator fails to generate clients for Showcase v0.0.13 because of these path templates that don't start with `/`.

```
ERROR: google/showcase/v1alpha3/messaging.proto:93:3: http: In path template 'v1alpha3/{parent=users/*/profile}/blurbs': effective path must start with leading '/'.
```

Fixing that (and will release v0.0.14 when fixed).