### PR TITLE
fix path template field names

### DIFF
--- a/schema/messaging.proto
+++ b/schema/messaging.proto
@@ -174,7 +174,7 @@ service Messaging {
       post: "/v1alpha3/{name=rooms/*}/blurbs:stream"
       body: "*"
       additional_bindings: {
-        post: "/v1alpha3/{parent=users/*/profile}/blurbs:stream"
+        post: "/v1alpha3/{name=users/*/profile}/blurbs:stream"
         body: "*"
       }
     };

--- a/schema/testing.proto
+++ b/schema/testing.proto
@@ -73,7 +73,7 @@ service Testing {
   // List the tests of a sessesion.
   rpc ListTests(ListTestsRequest) returns (ListTestsResponse) {
     option (google.api.http) = {
-      get: "/v1alpha3/{name=sessions/*}/tests"
+      get: "/v1alpha3/{parent=sessions/*}/tests"
     };
   }
 


### PR DESCRIPTION
One more!

```
ERROR: google/showcase/v1alpha3/testing.proto:74:3: http: undefined field 'name' on message 'google.showcase.v1alpha3.ListTestsRequest'.
ERROR: google/showcase/v1alpha3/messaging.proto:172:3: http: undefined field 'parent' on message 'google.showcase.v1alpha3.StreamBlurbsRequest'.
```

@landrito Can you please take a look to check if my changes to path template are OK (feel free to update it if not). I'm not really sure that I used the right field names.

Thanks!