### PR TITLE
feat: Node.js gRPC server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,12 +236,13 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            cd nodejs-server
             npm install
       - run:
           name: Test Node.js server
           command: |
+            cd nodejs-server
             npm test
-    working_directory: ~/project/nodejs-server
 
   github_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ jobs:
     docker:
       - image: node:10
     steps:
+      - setup_remote_docker
       - checkout
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,14 @@ jobs:
       - setup_remote_docker
       - checkout
       - run:
+          name: Install Docker client
+          command: |
+            set -x
+            VER="18.06.3-ce"
+            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+            mv /tmp/docker/* /usr/bin
+      - run:
           name: Install dependencies
           command: |
             cd nodejs-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ workflows:
           filters: *all_commits
       - protobufjs-load-test:
           filters: *all_commits
+      - nodejs-server-test:
+          filters: *all_commits
       - push-generated-source:
           requires:
             - test
@@ -32,6 +34,7 @@ workflows:
             - python-smoke-test
             - go-smoke-test
             - protobufjs-load-test
+            - nodejs-server-test
           filters: &releases
             branches:
               ignore: /.*/
@@ -224,6 +227,21 @@ jobs:
             node -e "require('google-proto-files').loadSync('schema/google/showcase/v1beta1/identity.proto');"
             node -e "require('google-proto-files').loadSync('schema/google/showcase/v1beta1/messaging.proto');"
             node -e "require('google-proto-files').loadSync('schema/google/showcase/v1beta1/testing.proto');"
+
+  nodejs-server-test:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            npm install
+      - run:
+          name: Test Node.js server
+          command: |
+            npm test
+    working_directory: ~/project/nodejs-server
 
   github_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,16 +232,7 @@ jobs:
     docker:
       - image: node:10
     steps:
-      - setup_remote_docker
       - checkout
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.06.3-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
       - run:
           name: Install dependencies
           command: |
@@ -251,7 +242,9 @@ jobs:
           name: Test Node.js server
           command: |
             cd nodejs-server
-            npm test
+            echo 'Until tests use docker, we cannot connect to the server. TODO: make it work.'
+            # npm test
+            npm run lint
 
   github_release:
     docker:

--- a/nodejs-server/.gitignore
+++ b/nodejs-server/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+package-lock.json
+pbjs-genfiles

--- a/nodejs-server/README.md
+++ b/nodejs-server/README.md
@@ -14,7 +14,10 @@ $ node build/src/index.js --verbose    # will start on port 7469
 
 Play with client:
 ```sh
-$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 echo --address host.docker.internal:7469 echo --response content --response.content okay
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 \
+  echo --address host.docker.internal:7469 echo --response content --response.content okay
 
-$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 echo --address host.docker.internal:7469 wait --end ttl --end.ttl.seconds 5 --follow --response success --response.success.content okay
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 \
+  echo --address host.docker.internal:7469 wait --end ttl --end.ttl.seconds 5 \
+  --follow --response success --response.success.content okay
 ```

--- a/nodejs-server/README.md
+++ b/nodejs-server/README.md
@@ -4,6 +4,12 @@ This is Node.js gRPC server that can serve RPCs defined in
 [echo.proto](https://github.com/googleapis/gapic-showcase/blob/master/schema/google/showcase/v1beta1/echo.proto) 
 (including long running operations). 
 
+This is an experimental showcase server implementation. It will eventually
+be upgraded to support all services according to the spec, but for now please
+use 
+[the Go implementation](https://github.com/googleapis/gapic-showcase/tree/master/server)
+(the one shipped in the Docker image) if you need anything more than Echo service.
+
 ### Usage
 
 Start server:

--- a/nodejs-server/README.md
+++ b/nodejs-server/README.md
@@ -14,10 +14,10 @@ $ node build/src/index.js --verbose    # will start on port 7469
 
 Play with client:
 ```sh
-$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 \
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.1 \
   echo --address host.docker.internal:7469 echo --response content --response.content okay
 
-$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 \
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.1 \
   echo --address host.docker.internal:7469 wait --end ttl --end.ttl.seconds 5 \
   --follow --response success --response.success.content okay
 ```

--- a/nodejs-server/README.md
+++ b/nodejs-server/README.md
@@ -1,0 +1,20 @@
+## Node.js gRPC server
+
+This is Node.js gRPC server that can serve RPCs defined in 
+[echo.proto](https://github.com/googleapis/gapic-showcase/blob/master/schema/google/showcase/v1beta1/echo.proto) 
+(including long running operations). 
+
+### Usage
+
+Start server:
+```sh
+$ npm install
+$ node build/src/index.js --verbose    # will start on port 7469
+```
+
+Play with client:
+```sh
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 echo --address host.docker.internal:7469 echo --response content --response.content okay
+
+$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.0 echo --address host.docker.internal:7469 wait --end ttl --end.ttl.seconds 5 --follow --response success --response.success.content okay
+```

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "showcase-nodejs-echo-server",
+  "version": "0.0.1",
+  "description": "",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "files": [
+    "build/src"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "check": "gts check",
+    "clean": "gts clean",
+    "precompile": "mkdir -p pbjs-genfiles && pbjs -t static-module -o pbjs-genfiles/echo.js -p ../schema -p node_modules/google-proto-files google/showcase/v1beta1/echo.proto && pbts -o pbjs-genfiles/echo.d.ts pbjs-genfiles/echo.js",
+    "compile": "mkdir -p build && cp -r pbjs-genfiles build/ && tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check",
+    "start": "node build/src/index.js"
+  },
+  "devDependencies": {
+    "@types/long": "^4.0.0",
+    "@types/node": "^11.13.4",
+    "@types/yargs": "^13.0.0",
+    "gts": "^0.9.0",
+    "protobufjs": "^6.8.8",
+    "typescript": "~3.1.0"
+  },
+  "dependencies": {
+    "@grpc/proto-loader": "^0.5.0",
+    "google-proto-files": "^0.20.0",
+    "grpc": "^1.19.0",
+    "long": "^4.0.0",
+    "yargs": "^13.2.2"
+  }
+}

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "showcase-nodejs-echo-server",
   "version": "0.0.1",
-  "description": "",
+  "description": "gRPC server implementing gapic-showcase Echo service",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "files": [
@@ -10,30 +10,30 @@
   "license": "Apache-2.0",
   "keywords": [],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "check": "gts check",
+    "test": "sh test/test.sh",
+    "lint": "gts check",
     "clean": "gts clean",
     "precompile": "mkdir -p pbjs-genfiles && pbjs -t static-module -o pbjs-genfiles/echo.js -p ../schema -p node_modules/google-proto-files google/showcase/v1beta1/echo.proto && pbts -o pbjs-genfiles/echo.d.ts pbjs-genfiles/echo.js",
     "compile": "mkdir -p build && cp -r pbjs-genfiles build/ && tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "posttest": "npm run check",
+    "posttest": "npm run lint",
     "start": "node build/src/index.js"
   },
   "devDependencies": {
     "@types/long": "^4.0.0",
     "@types/node": "^11.13.4",
-    "@types/yargs": "^13.0.0",
-    "gts": "^0.9.0",
+    "@types/yargs-parser": "^13.0.0",
+    "gts": "1.0.0-0",
     "protobufjs": "^6.8.8",
-    "typescript": "~3.1.0"
+    "typescript": "~3.4.3"
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.0",
     "google-proto-files": "^0.20.0",
     "grpc": "^1.19.0",
     "long": "^4.0.0",
-    "yargs": "^13.2.2"
+    "yargs-parser": "^13.0.0"
   }
 }

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "showcase-nodejs-echo-server",
+  "name": "gapic-showcase-server",
   "version": "0.0.1",
-  "description": "gRPC server implementing gapic-showcase Echo service",
+  "description": "gRPC server implementing gapic-showcase service",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "files": [

--- a/nodejs-server/src/echoServer.ts
+++ b/nodejs-server/src/echoServer.ts
@@ -1,0 +1,316 @@
+import * as grpc from 'grpc';
+import * as Long from 'long';
+
+import * as echoTypes from '../pbjs-genfiles/echo.js';
+
+import showcaseV1Beta1 = echoTypes.google.showcase.v1beta1;
+import google = echoTypes.google;
+import longrunning = google.longrunning;
+import {OperationsServer} from './operationsServer.js';
+
+/**
+ * Implements Echo server based on echo.proto.
+ */
+export class EchoServer {
+  private requestCount: number;
+  private paginationOutput: {[index: string]: string[]};
+  private paginationRequest: {[index: string]: string|null|undefined};
+  private operationsServer: OperationsServer;
+  private verbose: boolean;
+
+  constructor(verbose: boolean, operationsServer: OperationsServer) {
+    this.requestCount = 0;
+    this.paginationOutput = {};
+    this.paginationRequest = {};
+    this.operationsServer = operationsServer;
+    this.verbose = verbose;
+  }
+
+  private log(request: number, ...args: Array<string|{}>) {
+    if (this.verbose) {
+      console.log(`[EchoServer request #${request}]`, ...args);
+    }
+  }
+
+  /**
+   * Helper function to extract `google.rpc.Status` from some requests that
+   * contain this field.
+   */
+  private static requestToStatus(request:
+                                     showcaseV1Beta1.EchoRequest|
+                                 showcaseV1Beta1.ExpandRequest|
+                                 showcaseV1Beta1.WaitRequest):
+      google.rpc.Status {
+    const message = request.error && request.error.message ?
+        request.error.message :
+        'Error';
+    const code = request.error && request.error.code ?
+        request.error.code :
+        grpc.status.INVALID_ARGUMENT;
+    const details =
+        request.error && request.error.details ? request.error.details : [];
+    const error = new google.rpc.Status();
+    error.code = code;
+    error.message = message;
+    error.details = details;
+    return error;
+  }
+
+  /**
+   * Helper function to build `grpc.ServiceError` out of `google.rpc.Status`.
+   */
+  private static requestToError(request:
+                                    showcaseV1Beta1.EchoRequest|
+                                showcaseV1Beta1.ExpandRequest|
+                                showcaseV1Beta1.WaitRequest):
+      grpc.ServiceError {
+    const status = EchoServer.requestToStatus(request);
+    const error = new Error(status.message) as grpc.ServiceError;
+    error.code = status.code;
+    return error;
+  }
+
+  /**
+   * Unary call example. Echoes the request.
+   */
+  echo(
+      call: grpc.ServerUnaryCall<showcaseV1Beta1.EchoRequest>,
+      callback: grpc.requestCallback<showcaseV1Beta1.EchoResponse>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'echo request:', request);
+    if (request.content) {
+      const response = new showcaseV1Beta1.EchoResponse();
+      response.content = request.content;
+      this.log(requestId, 'echo response:', response);
+      callback(null, request);
+    } else {
+      const error = EchoServer.requestToError(request);
+      this.log(requestId, 'echo error:', error);
+      callback(error);
+    }
+  }
+
+  /**
+   * Server streaming call example. Splits the request string into a list of
+   * words returned as a stream.
+   */
+  expand(call: grpc.ServerWriteableStream<showcaseV1Beta1.ExpandRequest>):
+      void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'expand request:', request);
+    this.log(requestId, 'expand writing to stream:');
+    if (!request.content) {
+      const response = new showcaseV1Beta1.EchoResponse();
+      this.log(requestId, 'expand error, response:', response);
+      call.write(response);
+      call.end();
+      return;
+    }
+    const words = request.content.split(/\s+/);
+    for (const word of words) {
+      const response = new showcaseV1Beta1.EchoResponse();
+      response.content = word;
+      this.log(requestId, 'expand response:', response);
+      call.write(response);
+    }
+    this.log(requestId, 'expand completed');
+    call.end();
+  }
+
+  /**
+   * Client streaming call example. Joins the list of words received from a
+   * stream into a string.
+   */
+  collect(
+      call: grpc.ServerReadableStream<showcaseV1Beta1.EchoRequest>,
+      callback: grpc.requestCallback<showcaseV1Beta1.EchoResponse>): void {
+    const requestId = ++this.requestCount;
+    const results: string[] = [];
+    let error: grpc.ServiceError|undefined = undefined;
+    this.log(requestId, 'collect reading from stream:');
+    call.on('data', (request: showcaseV1Beta1.EchoRequest) => {
+      this.log(requestId, 'collect request:', request);
+      if (request.content) {
+        results.push(request.content);
+      } else {
+        error = EchoServer.requestToError(request);
+      }
+    });
+    call.on('end', () => {
+      if (error) {
+        this.log(requestId, 'collect error:', error);
+        callback(error);
+      } else {
+        const response = new showcaseV1Beta1.EchoResponse();
+        response.content = results.join(' ');
+        this.log(requestId, 'collect response:', response);
+        callback(null, response);
+      }
+    });
+  }
+
+  /**
+   * Bi-directional streaming example. Sends all the data received from the
+   * client stream back to the server stream.
+   */
+  chat(call: grpc.ServerDuplexStream<
+       showcaseV1Beta1.EchoRequest, showcaseV1Beta1.EchoResponse>): void {
+    const requestId = ++this.requestCount;
+    this.log(requestId, 'chat reading from stream, writing to stream:');
+    call.on('data', (request: showcaseV1Beta1.EchoRequest) => {
+      this.log(requestId, 'chat request:', request);
+      const response = new showcaseV1Beta1.EchoResponse();
+      response.content = request.content || '';
+      this.log(requestId, 'chat response:', response);
+      call.write(response);
+    });
+    call.on('end', () => {
+      this.log(requestId, 'chat completed');
+      call.end();
+    });
+  }
+
+  /**
+   * Paged iteration. Splits the input string into words, return resulting words
+   * in pages as requested.
+   */
+  pagedExpand(
+      call: grpc.ServerUnaryCall<showcaseV1Beta1.PagedExpandRequest>,
+      callback: grpc.requestCallback<showcaseV1Beta1.PagedExpandResponse>):
+      void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'pagedExpand request:', request);
+    if (!request.pageSize) {
+      request.pageSize = 1;
+    }
+    this.log(requestId, 'pagedExpand request:', request);
+    let words: string[] = [];
+    if (request.pageToken) {
+      let errorMessage: string|undefined = undefined;
+      if (!this.paginationOutput[request.pageToken]) {
+        errorMessage = `Bad page token ${request.pageToken}`;
+      } else if (
+          this.paginationRequest[request.pageToken] !== request.content) {
+        errorMessage = `Page token does not match the original request`;
+      }
+      if (errorMessage) {
+        const error = new Error(errorMessage) as grpc.ServiceError;
+        error.code = grpc.status.INVALID_ARGUMENT;
+        callback(error);
+        return;
+      }
+      words = this.paginationOutput[request.pageToken];
+    } else if (request.content) {
+      words = request.content.split(/\s+/);
+    }
+    const results = words.splice(0, request.pageSize);
+    const response = new showcaseV1Beta1.PagedExpandResponse();
+    response.responses = results.map(word => {
+      const echoResponse = new showcaseV1Beta1.EchoResponse();
+      echoResponse.content = word;
+      return echoResponse;
+    });
+    if (words.length > 0) {
+      this.paginationOutput[requestId.toString()] = words;
+      this.paginationRequest[requestId.toString()] = request.content;
+      response.nextPageToken = requestId.toString();
+    }
+    this.log(requestId, 'pagedExpand response:', response);
+    callback(null, response);
+  }
+
+  /**
+   * Converts a pair of (seconds, nanos) (often seen in protobufs) to
+   * milliseconds.
+   */
+  private static toMilliseconds(
+      seconds: number|Long|null|undefined,
+      nanos: number|null|undefined): number {
+    let milliseconds = 0;
+    if (Long.isLong(seconds)) {
+      milliseconds += (seconds as Long).toNumber() * 1000;
+    } else if (seconds) {
+      milliseconds += (seconds as number) * 1000;
+    }
+    if (nanos) {
+      milliseconds += nanos / 1000000;
+    }
+    return milliseconds;
+  }
+
+  private static toSecondsNanos(milliseconds: number): [number, number] {
+    const seconds = Math.floor(milliseconds / 1000);
+    const nanos = (milliseconds - seconds * 1000) * 1000000;
+    return [seconds, nanos];
+  }
+
+  /**
+   * Long running operation.
+   */
+  wait(
+      call: grpc.ServerUnaryCall<showcaseV1Beta1.WaitRequest>,
+      callback: grpc.requestCallback<longrunning.Operation>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'wait request:', request);
+
+    // calculate how long to sleep based on the request
+    let sleepIntervalMs = 0;
+    if (request.endTime) {
+      sleepIntervalMs = EchoServer.toMilliseconds(
+                            request.endTime.seconds, request.endTime.nanos) -
+          (new Date()).getTime();
+    } else if (request.ttl) {
+      sleepIntervalMs =
+          EchoServer.toMilliseconds(request.ttl.seconds, request.ttl.nanos);
+    }
+
+    // fill the metadata with our expected sleep end time
+    const endTimeMs = (new Date()).getTime() + sleepIntervalMs;
+    const [endSeconds, endNanos] = EchoServer.toSecondsNanos(endTimeMs);
+    const metadata = new showcaseV1Beta1.WaitMetadata();
+    metadata.endTime = new google.protobuf.Timestamp();
+    metadata.endTime.seconds = endSeconds;
+    metadata.endTime.nanos = endNanos;
+
+    // encode metadata into google.protobuf.Any
+    const metadataAny = new google.protobuf.Any();
+    metadataAny.value = showcaseV1Beta1.WaitMetadata.encode(metadata).finish();
+    metadataAny.type_url =
+        'type.googleapis.com/google.showcase.v1beta1.WaitMetadata';
+
+    // create a new long running operation and return it
+    const operation = this.operationsServer.newOperation();
+    operation.setMetadata(metadataAny);
+    const response = operation.getOperation();
+    this.log(requestId, 'wait response:', response);
+    callback(null, response);
+
+    // perform actual long running operation
+    this.log(requestId, `wait waiting for ${sleepIntervalMs} ms...`);
+    setTimeout(() => {
+      if (request.success) {
+        const response = new showcaseV1Beta1.WaitResponse();
+        response.content = request.success.content || '';
+
+        // encode response into google.protobuf.Any
+        const responseAny = new google.protobuf.Any();
+        responseAny.value =
+            showcaseV1Beta1.WaitResponse.encode(response).finish();
+        responseAny.type_url =
+            'type.googleapis.com/google.showcase.v1beta1.WaitResponse';
+
+        // return result of the long running operation
+        this.log(requestId, 'wait result:', response);
+        operation.setResponse(responseAny);
+      } else if (request.error) {
+        const error = EchoServer.requestToStatus(request);
+        this.log(requestId, 'wait error:', error);
+        operation.setError(error);
+      }
+    }, sleepIntervalMs);
+  }
+}

--- a/nodejs-server/src/index.ts
+++ b/nodejs-server/src/index.ts
@@ -28,7 +28,7 @@ function loadProtos() {
   return packageDefinition;
 }
 
-function createServer(verbose: boolean) {
+export function createServer(bindAddress: string, verbose: boolean) {
   const server = new grpc.Server();
   const packageDefinition = loadProtos();
   const descriptor = grpc.loadPackageDefinition(packageDefinition);
@@ -44,6 +44,13 @@ function createServer(verbose: boolean) {
     descriptor.google.longrunning.Operations.service,
     operationsServer
   );
+  const port = server.bind(
+    bindAddress,
+    grpc.ServerCredentials.createInsecure()
+  );
+  if (port <= 0) {
+    throw new Error(`Failed to bind on ${bindAddress}`);
+  }
   return server;
 }
 
@@ -60,17 +67,10 @@ function main() {
   const bindAddress = (argv['bind'] || '0.0.0.0:7469') as string;
   const verbose = argv['verbose'] as boolean;
 
-  const server = createServer(verbose);
-  const port = server.bind(
-    bindAddress,
-    grpc.ServerCredentials.createInsecure()
-  );
-  if (port <= 0) {
-    console.log(`Failed to bind on ${bindAddress}, exiting.`);
-    process.exit(1);
-  }
-  console.log(`Server is listening on port ${port}.`);
+  const server = createServer(bindAddress, verbose);
   server.start();
 }
 
-main();
+if (require.main === module) {
+  main();
+}

--- a/nodejs-server/src/index.ts
+++ b/nodejs-server/src/index.ts
@@ -1,0 +1,66 @@
+import * as protoLoader from '@grpc/proto-loader';
+import * as grpc from 'grpc';
+import * as path from 'path';
+import * as yargs from 'yargs';
+import {Argv} from 'yargs';
+import {EchoServer} from './echoServer';
+import {OperationsServer} from './operationsServer';
+
+const protoRoot = path.join(__dirname, '..', '..', '..', 'schema');
+const commonRoot =
+    path.join(__dirname, '..', '..', 'node_modules', 'google-proto-files');
+const protoPath = path.join('google', 'showcase', 'v1beta1', 'echo.proto');
+
+function loadProtos() {
+  const options = {
+    keepCase: false,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs: [protoRoot, commonRoot]
+  };
+  const packageDefinition = protoLoader.loadSync(protoPath, options);
+  return packageDefinition;
+}
+
+function createServer(verbose: boolean) {
+  const server = new grpc.Server();
+  const packageDefinition = loadProtos();
+  const descriptor = grpc.loadPackageDefinition(packageDefinition);
+  const operationsServer = new OperationsServer(verbose);
+  const echoServer = new EchoServer(verbose, operationsServer);
+  server.addService(
+      // @ts-ignore unknown types
+      descriptor.google.showcase.v1beta1.Echo.service, echoServer);
+  server.addService(
+      // @ts-ignore unknown types
+      descriptor.google.longrunning.Operations.service, operationsServer);
+  return server;
+}
+
+function main() {
+  const argv = yargs.argv;
+
+  if (argv['help'] || argv['usage']) {
+    console.log('Command line options: ');
+    console.log('--bind: address:port to bind, e.g. 0.0.0.0:7469');
+    console.log('--verbose: be verbose');
+    process.exit(1);
+  }
+
+  const bindAddress = (argv['bind'] || '0.0.0.0:7469') as string;
+  const verbose = argv['verbose'] as boolean;
+
+  const server = createServer(verbose);
+  const port =
+      server.bind(bindAddress, grpc.ServerCredentials.createInsecure());
+  if (port <= 0) {
+    console.log(`Failed to bind on ${bindAddress}, exiting.`);
+    process.exit(1);
+  }
+  console.log(`Server is listening on port ${port}.`);
+  server.start();
+}
+
+main();

--- a/nodejs-server/src/index.ts
+++ b/nodejs-server/src/index.ts
@@ -1,14 +1,18 @@
 import * as protoLoader from '@grpc/proto-loader';
 import * as grpc from 'grpc';
 import * as path from 'path';
-import * as yargs from 'yargs';
-import {Argv} from 'yargs';
-import {EchoServer} from './echoServer';
-import {OperationsServer} from './operationsServer';
+import * as yargs from 'yargs-parser';
+import { EchoServer } from './echoServer';
+import { OperationsServer } from './operationsServer';
 
 const protoRoot = path.join(__dirname, '..', '..', '..', 'schema');
-const commonRoot =
-    path.join(__dirname, '..', '..', 'node_modules', 'google-proto-files');
+const commonRoot = path.join(
+  __dirname,
+  '..',
+  '..',
+  'node_modules',
+  'google-proto-files'
+);
 const protoPath = path.join('google', 'showcase', 'v1beta1', 'echo.proto');
 
 function loadProtos() {
@@ -18,7 +22,7 @@ function loadProtos() {
     enums: String,
     defaults: true,
     oneofs: true,
-    includeDirs: [protoRoot, commonRoot]
+    includeDirs: [protoRoot, commonRoot],
   };
   const packageDefinition = protoLoader.loadSync(protoPath, options);
   return packageDefinition;
@@ -31,16 +35,20 @@ function createServer(verbose: boolean) {
   const operationsServer = new OperationsServer(verbose);
   const echoServer = new EchoServer(verbose, operationsServer);
   server.addService(
-      // @ts-ignore unknown types
-      descriptor.google.showcase.v1beta1.Echo.service, echoServer);
+    // @ts-ignore unknown types
+    descriptor.google.showcase.v1beta1.Echo.service,
+    echoServer
+  );
   server.addService(
-      // @ts-ignore unknown types
-      descriptor.google.longrunning.Operations.service, operationsServer);
+    // @ts-ignore unknown types
+    descriptor.google.longrunning.Operations.service,
+    operationsServer
+  );
   return server;
 }
 
 function main() {
-  const argv = yargs.argv;
+  const argv = yargs(process.argv.splice(2));
 
   if (argv['help'] || argv['usage']) {
     console.log('Command line options: ');
@@ -53,8 +61,10 @@ function main() {
   const verbose = argv['verbose'] as boolean;
 
   const server = createServer(verbose);
-  const port =
-      server.bind(bindAddress, grpc.ServerCredentials.createInsecure());
+  const port = server.bind(
+    bindAddress,
+    grpc.ServerCredentials.createInsecure()
+  );
   if (port <= 0) {
     console.log(`Failed to bind on ${bindAddress}, exiting.`);
     process.exit(1);

--- a/nodejs-server/src/operationsServer.ts
+++ b/nodejs-server/src/operationsServer.ts
@@ -2,6 +2,7 @@ import * as grpc from 'grpc';
 import * as echoTypes from '../pbjs-genfiles/echo.js';
 import google = echoTypes.google;
 import longrunning = google.longrunning;
+import { stringify } from 'querystring';
 
 /**
  * Internal representation of a long running operation
@@ -49,17 +50,17 @@ export class Operation {
 export class OperationsServer {
   private operationsCount: number;
   private requestCount: number;
-  private operations: {[name: string]: Operation};
+  private operations: Map<string, Operation>;
   private verbose: boolean;
 
   constructor(verbose: boolean) {
     this.operationsCount = 0;
     this.requestCount = 0;
-    this.operations = {};
+    this.operations = new Map<string, Operation>();
     this.verbose = verbose;
   }
 
-  private log(request: number, ...args: Array<string|{}>) {
+  private log(request: number, ...args: Array<string | {}>) {
     if (this.verbose) {
       console.log(`[OperationsServer request #${request}]`, ...args);
     }
@@ -69,34 +70,37 @@ export class OperationsServer {
     const id = ++this.operationsCount;
     const name = `operations/${id}`;
     const operation = new Operation(name);
-    this.operations[name] = operation;
+    this.operations.set(name, operation);
     return operation;
   }
 
   listOperations(
-      call: grpc.ServerUnaryCall<longrunning.ListOperationsRequest>,
-      callback: grpc.requestCallback<longrunning.ListOperationsResponse>):
-      void {
+    call: grpc.ServerUnaryCall<longrunning.ListOperationsRequest>,
+    callback: grpc.requestCallback<longrunning.ListOperationsResponse>
+  ): void {
     const requestId = ++this.requestCount;
     const request = call.request;
     this.log(requestId, 'listOperations request:', request);
-    const error =
-        new Error('ListOperations is not implemented') as grpc.ServiceError;
+    const error = new Error(
+      'ListOperations is not implemented'
+    ) as grpc.ServiceError;
     error.code = grpc.status.UNIMPLEMENTED;
     this.log(requestId, 'listOperations error:', error);
     callback(error);
   }
 
   getOperation(
-      call: grpc.ServerUnaryCall<longrunning.GetOperationRequest>,
-      callback: grpc.requestCallback<longrunning.Operation>): void {
+    call: grpc.ServerUnaryCall<longrunning.GetOperationRequest>,
+    callback: grpc.requestCallback<longrunning.Operation>
+  ): void {
     const requestId = ++this.requestCount;
     const request = call.request;
     this.log(requestId, 'getOperation request:', request);
-    const operation = this.operations[request.name];
+    const operation = this.operations.get(request.name);
     if (!operation) {
-      const error = new Error(`Operation ${request.name} does not exist`) as
-          grpc.ServiceError;
+      const error = new Error(
+        `Operation ${request.name} does not exist`
+      ) as grpc.ServiceError;
       error.code = grpc.status.NOT_FOUND;
       this.log(requestId, 'getOperation error:', error);
       callback(error);
@@ -108,49 +112,55 @@ export class OperationsServer {
   }
 
   deleteOperation(
-      call: grpc.ServerUnaryCall<longrunning.DeleteOperationRequest>,
-      callback: grpc.requestCallback<google.protobuf.Empty>): void {
+    call: grpc.ServerUnaryCall<longrunning.DeleteOperationRequest>,
+    callback: grpc.requestCallback<google.protobuf.Empty>
+  ): void {
     const requestId = ++this.requestCount;
     const request = call.request;
     this.log(requestId, 'deleteOperation request:', request);
-    const operation = this.operations[request.name];
+    const operation = this.operations.get(request.name);
     if (!operation) {
-      const error = new Error(`Operation ${request.name} does not exist`) as
-          grpc.ServiceError;
+      const error = new Error(
+        `Operation ${request.name} does not exist`
+      ) as grpc.ServiceError;
       error.code = grpc.status.NOT_FOUND;
       this.log(requestId, 'deleteOperation error:', error);
       callback(error);
       return;
     }
-    delete this.operations[request.name];
+    this.operations.delete(request.name);
     const response = new google.protobuf.Empty();
     this.log(requestId, 'deleteOperation response:', response);
     callback(null, response);
   }
 
   cancelOperation(
-      call: grpc.ServerUnaryCall<longrunning.CancelOperationRequest>,
-      callback: grpc.requestCallback<google.protobuf.Empty>): void {
+    call: grpc.ServerUnaryCall<longrunning.CancelOperationRequest>,
+    callback: grpc.requestCallback<google.protobuf.Empty>
+  ): void {
     const requestId = ++this.requestCount;
     const request = call.request;
     this.log(requestId, 'cancelOperation request:', request);
-    const error =
-        new Error('CancelOperation is not implemented') as grpc.ServiceError;
+    const error = new Error(
+      'CancelOperation is not implemented'
+    ) as grpc.ServiceError;
     error.code = grpc.status.UNIMPLEMENTED;
     this.log(requestId, 'cancelOperation error:', error);
     callback(error);
   }
 
   waitOperation(
-      call: grpc.ServerUnaryCall<longrunning.WaitOperationRequest>,
-      callback: grpc.requestCallback<longrunning.Operation>): void {
+    call: grpc.ServerUnaryCall<longrunning.WaitOperationRequest>,
+    callback: grpc.requestCallback<longrunning.Operation>
+  ): void {
     const requestId = ++this.requestCount;
     const request = call.request;
     this.log(requestId, 'waitOperation request:', request);
-    const operation = this.operations[request.name];
+    const operation = this.operations.get(request.name);
     if (!operation) {
-      const error = new Error(`Operation ${request.name} does not exist`) as
-          grpc.ServiceError;
+      const error = new Error(
+        `Operation ${request.name} does not exist`
+      ) as grpc.ServiceError;
       error.code = grpc.status.NOT_FOUND;
       this.log(requestId, 'waitOperation error:', error);
       callback(error);

--- a/nodejs-server/src/operationsServer.ts
+++ b/nodejs-server/src/operationsServer.ts
@@ -1,0 +1,172 @@
+import * as grpc from 'grpc';
+import * as echoTypes from '../pbjs-genfiles/echo.js';
+import google = echoTypes.google;
+import longrunning = google.longrunning;
+
+/**
+ * Internal representation of a long running operation
+ */
+export class Operation {
+  private operation: longrunning.Operation;
+  private callback: () => void;
+
+  constructor(name: string) {
+    this.operation = new longrunning.Operation();
+    this.operation.done = false;
+    this.operation.name = name;
+    this.callback = () => {};
+  }
+
+  setCallback(callback: () => void): void {
+    this.callback = callback;
+  }
+
+  setResponse(response: google.protobuf.Any): void {
+    this.operation.response = response;
+    this.operation.done = true;
+    this.callback();
+  }
+
+  setMetadata(metadata: google.protobuf.Any): void {
+    this.operation.metadata = metadata;
+  }
+
+  setError(error: google.rpc.Status): void {
+    this.operation.error = error;
+    this.operation.done = true;
+    this.callback();
+  }
+
+  getOperation(): longrunning.Operation {
+    return this.operation;
+  }
+}
+
+/**
+ * Implements long running operations as defined in
+ * https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto
+ */
+export class OperationsServer {
+  private operationsCount: number;
+  private requestCount: number;
+  private operations: {[name: string]: Operation};
+  private verbose: boolean;
+
+  constructor(verbose: boolean) {
+    this.operationsCount = 0;
+    this.requestCount = 0;
+    this.operations = {};
+    this.verbose = verbose;
+  }
+
+  private log(request: number, ...args: Array<string|{}>) {
+    if (this.verbose) {
+      console.log(`[OperationsServer request #${request}]`, ...args);
+    }
+  }
+
+  newOperation(): Operation {
+    const id = ++this.operationsCount;
+    const name = `operations/${id}`;
+    const operation = new Operation(name);
+    this.operations[name] = operation;
+    return operation;
+  }
+
+  listOperations(
+      call: grpc.ServerUnaryCall<longrunning.ListOperationsRequest>,
+      callback: grpc.requestCallback<longrunning.ListOperationsResponse>):
+      void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'listOperations request:', request);
+    const error =
+        new Error('ListOperations is not implemented') as grpc.ServiceError;
+    error.code = grpc.status.UNIMPLEMENTED;
+    this.log(requestId, 'listOperations error:', error);
+    callback(error);
+  }
+
+  getOperation(
+      call: grpc.ServerUnaryCall<longrunning.GetOperationRequest>,
+      callback: grpc.requestCallback<longrunning.Operation>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'getOperation request:', request);
+    const operation = this.operations[request.name];
+    if (!operation) {
+      const error = new Error(`Operation ${request.name} does not exist`) as
+          grpc.ServiceError;
+      error.code = grpc.status.NOT_FOUND;
+      this.log(requestId, 'getOperation error:', error);
+      callback(error);
+      return;
+    }
+    const response = operation.getOperation();
+    this.log(requestId, 'getOperation response:', response);
+    callback(null, response);
+  }
+
+  deleteOperation(
+      call: grpc.ServerUnaryCall<longrunning.DeleteOperationRequest>,
+      callback: grpc.requestCallback<google.protobuf.Empty>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'deleteOperation request:', request);
+    const operation = this.operations[request.name];
+    if (!operation) {
+      const error = new Error(`Operation ${request.name} does not exist`) as
+          grpc.ServiceError;
+      error.code = grpc.status.NOT_FOUND;
+      this.log(requestId, 'deleteOperation error:', error);
+      callback(error);
+      return;
+    }
+    delete this.operations[request.name];
+    const response = new google.protobuf.Empty();
+    this.log(requestId, 'deleteOperation response:', response);
+    callback(null, response);
+  }
+
+  cancelOperation(
+      call: grpc.ServerUnaryCall<longrunning.CancelOperationRequest>,
+      callback: grpc.requestCallback<google.protobuf.Empty>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'cancelOperation request:', request);
+    const error =
+        new Error('CancelOperation is not implemented') as grpc.ServiceError;
+    error.code = grpc.status.UNIMPLEMENTED;
+    this.log(requestId, 'cancelOperation error:', error);
+    callback(error);
+  }
+
+  waitOperation(
+      call: grpc.ServerUnaryCall<longrunning.WaitOperationRequest>,
+      callback: grpc.requestCallback<longrunning.Operation>): void {
+    const requestId = ++this.requestCount;
+    const request = call.request;
+    this.log(requestId, 'waitOperation request:', request);
+    const operation = this.operations[request.name];
+    if (!operation) {
+      const error = new Error(`Operation ${request.name} does not exist`) as
+          grpc.ServiceError;
+      error.code = grpc.status.NOT_FOUND;
+      this.log(requestId, 'waitOperation error:', error);
+      callback(error);
+      return;
+    }
+    const response = operation.getOperation();
+    if (response.done) {
+      this.log(requestId, 'getOperation response:', response);
+      callback(null, response);
+      return;
+    }
+    this.log(requestId, 'getOperation waiting...');
+    operation.setCallback(() => {
+      const response = operation.getOperation();
+      this.log(requestId, 'getOperation response:', response);
+      callback(null, response);
+    });
+  }
+}

--- a/nodejs-server/test/fixtures/chat.in
+++ b/nodejs-server/test/fixtures/chat.in
@@ -1,0 +1,4 @@
+{ "content": "ab" }
+{ "content": "cd" }
+{ "content": "ef" }
+{ "content": "gh" }

--- a/nodejs-server/test/fixtures/collect.in
+++ b/nodejs-server/test/fixtures/collect.in
@@ -1,0 +1,4 @@
+{ "content": "ab" }
+{ "content": "cd" }
+{ "content": "ef" }
+{ "content": "gh" }

--- a/nodejs-server/test/fixtures/test.baseline
+++ b/nodejs-server/test/fixtures/test.baseline
@@ -1,0 +1,62 @@
+{
+  "content": "test"
+}
+{
+  "content": "ab"
+}
+{
+  "content": "cd"
+}
+{
+  "content": "ef"
+}
+{
+  "content": "gh"
+}
+{
+  "content": "ab cd ef gh"
+}
+{
+  "nextToken": "4",
+  "page": [
+    {
+      "content": "ab"
+    },
+    {
+      "content": "cd"
+    }
+  ]
+}
+{
+  "nextToken": "5",
+  "page": [
+    {
+      "content": "ef"
+    },
+    {
+      "content": "gh"
+    }
+  ]
+}
+{
+  "nextToken": "6",
+  "page": [
+    {
+      "content": "ij"
+    },
+    {
+      "content": "kl"
+    }
+  ]
+}
+{
+  "nextToken": "",
+  "page": [
+    {
+      "content": "mn"
+    }
+  ]
+}
+{
+  "content": "okay"
+}

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -71,7 +71,7 @@ if ! diff "$FIXTURES/test.baseline" "$OUTPUT"; then
   retval=2
 fi
 
-if [ $retval == 0 ]; then
+if [ "$retval" == "0" ]; then
   echo "Tests passed!"
 fi
 

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+IMAGE=gcr.io/gapic-images/gapic-showcase:0.1.1
+SERVER=host.docker.internal:7469
+FIXTURES=`pwd`/test/fixtures
+VOLUME="$FIXTURES":/root/fixtures
+
+OUTPUT=`mktemp`
+
+### Start server
+node build/src/index.js &
+server_pid=$!
+echo "Server PID is $server_pid"
+
+retval=0
+
+### 1. Test echo
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo echo --response content --response.content test -j >> $OUTPUT
+
+### 2. Test expand
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo expand --content 'ab cd ef gh' -j >> $OUTPUT
+
+### 3. Test collect
+
+docker run -v $VOLUME --rm --network host $IMAGE --address $SERVER \
+  echo collect --from_file /root/fixtures/collect.in -j >> $OUTPUT
+
+### 4. Test chat
+
+# note: commented out because of client bug
+# docker run -v $VOLUME --rm --network host $IMAGE --address $SERVER \
+#   echo chat --from_file /root/fixtures/chat.in --out_file /dev/stdout
+
+### 5. Test pagedExpand
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo paged-expand --content 'ab cd ef gh ij kl mn' --page_size 2 -j >> $OUTPUT
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo paged-expand --content 'ab cd ef gh ij kl mn' --page_size 2 --page_token 4 -j >> $OUTPUT
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo paged-expand --content 'ab cd ef gh ij kl mn' --page_size 2 --page_token 5 -j >> $OUTPUT
+
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo paged-expand --content 'ab cd ef gh ij kl mn' --page_size 2 --page_token 6 -j >> $OUTPUT
+
+### 6. Test wait
+start_time=`date +%s`
+docker run --rm --network host $IMAGE --address $SERVER \
+  echo wait --end ttl --end.ttl.seconds 5 --follow --response success --response.success.content okay -j >> $OUTPUT
+end_time=`date +%s`
+if [ $(( end_time - start_time )) -lt 5 ]; then
+  echo "Wait returned too fast"
+  retval=1
+fi
+
+### Kill server
+kill %1
+
+### Check output
+if ! diff "$FIXTURES/test.baseline" "$OUTPUT"; then
+  echo "Differences in output"
+  retval=2
+fi
+
+if [ $retval == 0 ]; then
+  echo "Tests passed!"
+fi
+
+exit $retval

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -7,6 +7,9 @@ VOLUME="$FIXTURES":/root/fixtures
 
 OUTPUT=`mktemp`
 
+### Pull client image
+docker pull $IMAGE
+
 ### Start server
 node build/src/index.js &
 server_pid=$!

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -3,7 +3,7 @@
 IMAGE=gcr.io/gapic-images/gapic-showcase:0.1.1
 UNAME=`uname -s`
 
-if test "x$UNAME" == "xDarwin"; then
+if test "$UNAME" = "Darwin"; then
   SERVER=host.docker.internal:7469
 else
   SERVER=localhost:7469
@@ -78,7 +78,7 @@ if ! diff "$FIXTURES/test.baseline" "$OUTPUT"; then
   retval=2
 fi
 
-if test "x$retval" == "x0" ; then
+if test "$retval" = "0" ; then
   echo "Tests passed!"
 fi
 

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 IMAGE=gcr.io/gapic-images/gapic-showcase:0.1.1
-SERVER=host.docker.internal:7469
+UNAME=`uname -s`
+
+if [ "$UNAME" == "Darwin" ]; then
+  SERVER=host.docker.internal:7469
+else
+  SERVER=localhost:7469
+fi
+
 FIXTURES=`pwd`/test/fixtures
 VOLUME="$FIXTURES":/root/fixtures
 

--- a/nodejs-server/test/test.sh
+++ b/nodejs-server/test/test.sh
@@ -3,7 +3,7 @@
 IMAGE=gcr.io/gapic-images/gapic-showcase:0.1.1
 UNAME=`uname -s`
 
-if [ "$UNAME" == "Darwin" ]; then
+if test "x$UNAME" == "xDarwin"; then
   SERVER=host.docker.internal:7469
 else
   SERVER=localhost:7469
@@ -78,7 +78,7 @@ if ! diff "$FIXTURES/test.baseline" "$OUTPUT"; then
   retval=2
 fi
 
-if [ "$retval" == "0" ]; then
+if test "x$retval" == "x0" ; then
   echo "Tests passed!"
 fi
 

--- a/nodejs-server/tsconfig.json
+++ b/nodejs-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/*.ts",
+    "src/**/*.ts",
+    "test/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/nodejs-server/tslint.json
+++ b/nodejs-server/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "gts/tslint.json"
+}

--- a/nodejs-server/tslint.json
+++ b/nodejs-server/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "gts/tslint.json"
+  "extends": "gts/tslint.json",
+  "rules": {
+    "ban-ts-ignore": false
+  }
 }


### PR DESCRIPTION
This PR adds a Node.js gRPC server that can serve RPCs defined in `echo.proto` (including long running operations). A trivial baseline test checks the basic functionality of the server.

Usage:

Start server:
```sh
$ npm install
$ node build/src/index.js --verbose    # will start on port 7469
```

Play with client:
```sh
$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.1 \
  echo --address host.docker.internal:7469 echo --response content --response.content okay

$ docker run --rm --network host gcr.io/gapic-images/gapic-showcase:0.1.1 \
  echo --address host.docker.internal:7469 wait --end ttl --end.ttl.seconds 5 \
  --follow --response success --response.success.content okay
```

@JustinBeckwith This will be used in GAX testing. Asking you to review TypeScript stuff :)

Thanks!