### PR TITLE
Update resource annotations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
               --rm \
               --mount type=bind,source="$(pwd)"/schema,destination=/in/protos/google/showcase/v1beta1,readonly \
               --mount type=bind,source="$(pwd)"/goout,destination=/out/ \
-              gcr.io/gapic-images/gapic-generator-go:v0.4 \
+              gcr.io/gapic-images/gapic-generator-go:0.5 \
               --go-gapic-package "<github.com/googleapis/gapic-showcase/client;client>"
 
   protobufjs-load-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
             docker run --rm \
               --mount type=bind,source="$(pwd)"/schema/,destination=/in/google/showcase/v1beta1/,readonly \
               --mount type=bind,source="$(pwd)"/pyout,target=/out \
-              gcr.io/gapic-images/gapic-generator-python:0.6
+              gcr.io/gapic-images/gapic-generator-python:0.9
 
   go-smoke-test:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ workflows:
           requires:
             - build
           filters: *all_commits
-      - kotlin-smoke-test:
-          filters: *all_commits
       - python-smoke-test:
           filters: *all_commits
       - go-smoke-test:
@@ -30,7 +28,6 @@ workflows:
       - github_release:
           requires:
             - test
-            - kotlin-smoke-test
             - python-smoke-test
             - go-smoke-test
             - protobufjs-load-test
@@ -43,7 +40,6 @@ workflows:
       - push-image:
           requires:
             - test
-            - kotlin-smoke-test
             - python-smoke-test
             - go-smoke-test
             - protobufjs-load-test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "schema/api-common-protos"]
 	path = schema/api-common-protos
 	url = https://github.com/googleapis/api-common-protos.git
-  branch = master
+	branch = v0.1.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "schema/api-common-protos"]
 	path = schema/api-common-protos
 	url = https://github.com/googleapis/api-common-protos.git
+  branch = master

--- a/schema/google/showcase/v1beta1/identity.proto
+++ b/schema/google/showcase/v1beta1/identity.proto
@@ -77,8 +77,13 @@ service Identity {
 
 // A user.
 message User {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/User"
+    pattern: "users/{user_id}"
+  };
+
   // The resource name of the user.
-  string name = 1 [(google.api.resource).pattern = "users/{user_id}"];
+  string name = 1;
 
   // The display_name of the user.
   string display_name = 2 [(google.api.field_behavior) = REQUIRED];
@@ -109,7 +114,7 @@ message CreateUserRequest {
 message GetUserRequest {
   // The resource name of the requested user.
   string name = 1 [
-    (google.api.resource_reference) = "User",
+    (google.api.resource_reference).type = "showcase.googleapis.com/User",
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -130,7 +135,7 @@ message UpdateUserRequest {
 message DeleteUserRequest {
   // The resource name of the user to delete.
   string name = 1 [
-    (google.api.resource_reference) = "User",
+    (google.api.resource_reference).type = "showcase.googleapis.com/User",
     (google.api.field_behavior) = REQUIRED
   ];
 }

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -30,14 +30,6 @@ option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
 option java_package = "com.google.showcase.v1beta1";
 option java_multiple_files = true;
 
-// This resource is defined in google/showcase/v1beta1/user.proto. Since
-// google/showcase/v1beta1/user.proto is not imported from this file, the
-// resource needs to be defined here to be used in this API.
-option (google.api.resource_definition) = {
-  symbol: "User",
-  pattern: "users/{user_id}"
-};
-
 // A simple messaging service that implements chat rooms and profile posts.
 //
 // This messaging service showcases the features that API clients
@@ -202,8 +194,13 @@ service Messaging {
 
 // A chat room.
 message Room {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/Room"
+    pattern: "rooms/{room_id}"
+  };
+
   // The resource name of the chat room.
-  string name = 1 [(google.api.resource).pattern = "rooms/{room_id}"];
+  string name = 1;
 
   // The human readable name of the chat room.
   string display_name = 2 [(google.api.field_behavior) = REQUIRED];
@@ -234,7 +231,7 @@ message CreateRoomRequest {
 message GetRoomRequest {
   // The resource name of the requested room.
   string name = 1 [
-    (google.api.resource_reference) = "Room",
+    (google.api.resource_reference).type = "showcase.googleapis.com/Room",
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -255,7 +252,7 @@ message UpdateRoomRequest {
 message DeleteRoomRequest {
   // The resource name of the requested room.
   string name = 1 [
-    (google.api.resource_reference) = "Room",
+    (google.api.resource_reference).type = "showcase.googleapis.com/Room",
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -289,12 +286,18 @@ message ListRoomsResponse {
 // This protocol buffer message represents a blurb sent to a chat room or
 // posted on a user profile.
 message Blurb {
+  option (google.api.resource) = {
+    type: "google.showcase.com/Blurb"
+    pattern: "rooms/{room_id}/blurbs/{blurb_id}"
+    pattern: "user/{user_id}/profile/blurbs/{blurb_id}"
+  };
+
   // The resource name of the chat room.
   string name = 1;
 
   // The resource name of the blurb's author.
   string user = 2 [
-    (google.api.resource_reference) = "User",
+    (google.api.resource_reference).type = "showcase.googleapis.com/User",
     (google.api.field_behavior) = REQUIRED];
 
   oneof content {
@@ -322,7 +325,7 @@ message CreateBlurbRequest {
   // The resource name of the chat room or user profile that this blurb will
   // be tied to.
   string parent = 1 [
-    (google.api.resource_reference) = "BlurbParent",
+    (google.api.resource_reference).child_type = "showcase.googleapis.com/Blurb",
     (google.api.field_behavior) = REQUIRED
   ];
 
@@ -335,7 +338,7 @@ message CreateBlurbRequest {
 message GetBlurbRequest {
   // The resource name of the requested blurb.
   string name = 1 [
-    (google.api.resource_reference) = "Blurb",
+    (google.api.resource_reference).type = "showcase.googleapis.com/Blurb",
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -356,7 +359,7 @@ message UpdateBlurbRequest {
 message DeleteBlurbRequest {
   // The resource name of the requested blurb.
   string name = 1 [
-    (google.api.resource_reference) = "Blurb",
+    (google.api.resource_reference).type = "showcase.googleapis.com/Blurb",
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -366,7 +369,7 @@ message DeleteBlurbRequest {
 message ListBlurbsRequest {
   // The resource name of the requested room or profile whos blurbs to list.
   string parent = 1 [
-    (google.api.resource_reference) = "BlurbParent",
+    (google.api.resource_reference).child_type = "showcase.googleapis.com/Blurb",
     (google.api.field_behavior) = REQUIRED
   ];
 
@@ -404,7 +407,8 @@ message SearchBlurbsRequest {
 
   // The rooms or profiles to search. If unset, `SearchBlurbs` will search all
   // rooms and all profiles.
-  string parent = 2 [(google.api.resource_reference) = "BlurbParent"];
+  string parent = 2 [
+    (google.api.resource_reference).child_type = "showcase.googleapis.com/Blurb"];
 
   // The maximum number of blurbs return. Server may return fewer
   // blurbs than requested. If unspecified, server will pick an appropriate
@@ -443,7 +447,7 @@ message SearchBlurbsResponse {
 message StreamBlurbsRequest {
   // The resource name of a chat room or user profile whose blurbs to stream.
   string name = 1 [
-    (google.api.resource_reference) = "BlurbParent",
+    (google.api.resource_reference).child_type = "showcase.googleapis.com/Blurb",
     (google.api.field_behavior) = REQUIRED
   ];
 
@@ -489,7 +493,8 @@ message SendBlurbsResponse {
 message ConnectRequest {
   message ConnectConfig {
     // The room or profile to follow and create messages for.
-    string parent = 1 [(google.api.resource_reference) = "BlurbParent"];
+    string parent = 1 [
+      (google.api.resource_reference).child_type = "showcase.googleapis.com/Blurb"];
   }
 
   oneof request {

--- a/schema/google/showcase/v1beta1/testing.proto
+++ b/schema/google/showcase/v1beta1/testing.proto
@@ -106,9 +106,14 @@ service Testing {
 // A session defines tests it may expect, based on which version of the
 // code generation spec is in use.
 message Session {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/Session"
+    pattern: "sessions/{session}"
+  };
+
   // The name of the session. The ID must conform to ^[a-z]+$
   // If this is not provided, Showcase chooses one at random.
-  string name = 1 [(google.api.resource).pattern = "sessions/{session}"];
+  string name = 1;
 
   // The specification versions understood by Showcase.
   enum Version {
@@ -138,7 +143,8 @@ message CreateSessionRequest {
 // The request for the GetSession method.
 message GetSessionRequest {
   // The session to be retrieved.
-  string name = 1 [(google.api.resource_reference) = "Session"];
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Session"];
 }
 
 // The request for the ListSessions method.
@@ -163,13 +169,15 @@ message ListSessionsResponse {
 // Request for the DeleteSession method.
 message DeleteSessionRequest {
   // The session to be deleted.
-  string name = 1 [(google.api.resource_reference) = "Session"];
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Session"];
 }
 
 // Request message for reporting on a session.
 message ReportSessionRequest {
   // The session to be reported on.
-  string name = 1 [(google.api.resource_reference) = "Session"];
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Session"];
 }
 
 // Response message for reporting on a session.
@@ -196,10 +204,15 @@ message ReportSessionResponse {
 }
 
 message Test {
+  option (google.api.resource) = {
+    type: "showcase.googleapis.com/Test"
+    pattern: "sessions/{session}/tests/{test}"
+  };
+
   // The name of the test.
   // The tests/* portion of the names are hard-coded, and do not change
   // from session to session.
-  string name = 1 [(google.api.resource).pattern = "sessions/{session}/tests/{test}"];
+  string name = 1;
 
   // Whether or not a test is required, recommended, or optional.
   enum ExpectationLevel {
@@ -239,8 +252,13 @@ message Test {
   // by something more robust like CEL, but as of writing this, I am unsure if CEL
   // is ready.
   message Blueprint {
+    option (google.api.resource) = {
+      type: "showcase.googleapis.com/Blueprint"
+      pattern: "sessions/{session}/tests/{test}/blueprints/{blueprint}"
+    };
+
     // The name of this blueprint.
-    string name = 1 [(google.api.resource).pattern = "sessions/{session}/tests/{test}/blueprints/{blueprint}"];
+    string name = 1;
 
     // A description of this blueprint.
     string description = 2;
@@ -309,7 +327,8 @@ message Issue {
 // The request for the ListTests method.
 message ListTestsRequest {
   // The session.
-  string parent = 1 [(google.api.resource_reference) = "Session"];
+  string parent = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Session"];
 
   // The maximum number of tests to return per page.
   int32 page_size = 2;
@@ -333,7 +352,8 @@ message TestRun {
   // The name of the test.
   // The tests/* portion of the names are hard-coded, and do not change
   // from session to session.
-  string test = 1 [(google.api.resource_reference) = "Test"];
+  string test = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Test"];
 
 
   // An issue found with the test run. If empty, this test run was successful.
@@ -343,12 +363,14 @@ message TestRun {
 // Request message for deleting a test.
 message DeleteTestRequest {
   // The test to be deleted.
-  string name = 1 [(google.api.resource_reference) = "Test"];
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Test"];
 }
 
 message VerifyTestRequest {
   // The test to have an answer registered to it.
-  string name = 1 [(google.api.resource_reference) = "Test"];
+  string name = 1 [
+    (google.api.resource_reference).type = "showcase.googleapis.com/Test"];
 
   // The answer from the test.
   bytes answer = 2;


### PR DESCRIPTION
Updates resource annotations to use the latest resource.proto. This seems to break the smoke tests since presumably the base docker image of those tests do not yet support the protos.