### PR TITLE
Echo headers -> trailers

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -31,7 +31,8 @@ option java_multiple_files = true;
 // This service is used showcase the four main types of rpcs - unary, server
 // side streaming, client side streaming, and bidirectional streaming. This
 // service also exposes methods that explicitly implement server delay, and
-// paginated calls.
+// paginated calls. Set the 'showcase-trailer' metadata key on any method
+// to have the values echoed in the response trailers.
 service Echo {
   // This service is meant to only run locally on the port 7469 (keypad digits
   // for "show").

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -172,22 +172,24 @@ func (s *echoServerImpl) Block(ctx context.Context, in *pb.BlockRequest) (*pb.Bl
 // echo any provided trailing metadata
 func echoTrailers(ctx context.Context) {
 	md, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		values := md.Get("showcase-trailer")
-		for _, value := range values {
-			trailer := metadata.Pairs("showcase-trailer", value)
-			grpc.SetTrailer(ctx, trailer)
-		}
+	if !ok {
+		return
+	}
+	values := md.Get("showcase-trailer")
+	for _, value := range values {
+		trailer := metadata.Pairs("showcase-trailer", value)
+		grpc.SetTrailer(ctx, trailer)
 	}
 }
 
 func echoStreamingTrailers(stream grpc.ServerStream) {
 	md, ok := metadata.FromIncomingContext(stream.Context())
-	if ok {
-		values := md.Get("showcase-trailer")
-		for _, value := range values {
-			trailer := metadata.Pairs("showcase-trailer", value)
-			stream.SetTrailer(trailer)
-		}
+	if !ok {
+		return
+	}
+	values := md.Get("showcase-trailer")
+	for _, value := range values {
+		trailer := metadata.Pairs("showcase-trailer", value)
+		stream.SetTrailer(trailer)
 	}
 }

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -25,7 +25,9 @@ import (
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	lropb "google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -43,6 +45,7 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 	if err != nil {
 		return nil, err
 	}
+	echoTrailers(ctx)
 	return &pb.EchoResponse{Content: in.GetContent()}, nil
 }
 
@@ -56,6 +59,7 @@ func (s *echoServerImpl) Expand(in *pb.ExpandRequest, stream pb.Echo_ExpandServe
 	if in.GetError() != nil {
 		return status.ErrorProto(in.GetError())
 	}
+	echoStreamingTrailers(stream)
 	return nil
 }
 
@@ -65,6 +69,7 @@ func (s *echoServerImpl) Collect(stream pb.Echo_CollectServer) error {
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
+			echoStreamingTrailers(stream)
 			return stream.SendAndClose(&pb.EchoResponse{Content: strings.Join(resp, " ")})
 		}
 		if err != nil {
@@ -84,6 +89,7 @@ func (s *echoServerImpl) Chat(stream pb.Echo_ChatServer) error {
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
+			echoStreamingTrailers(stream)
 			return nil
 		}
 		if err != nil {
@@ -134,6 +140,7 @@ func (s *echoServerImpl) PagedExpand(ctx context.Context, in *pb.PagedExpandRequ
 		nextToken = strconv.Itoa(int(end))
 	}
 
+	echoTrailers(ctx)
 	return &pb.PagedExpandResponse{
 		Responses:     responses,
 		NextPageToken: nextToken,
@@ -148,6 +155,7 @@ func min(x int32, y int32) int32 {
 }
 
 func (s *echoServerImpl) Wait(ctx context.Context, in *pb.WaitRequest) (*lropb.Operation, error) {
+	echoTrailers(ctx)
 	return s.waiter.Wait(in), nil
 }
 
@@ -157,5 +165,29 @@ func (s *echoServerImpl) Block(ctx context.Context, in *pb.BlockRequest) (*pb.Bl
 	if in.GetError() != nil {
 		return nil, status.ErrorProto(in.GetError())
 	}
+	echoTrailers(ctx)
 	return in.GetSuccess(), nil
+}
+
+// echo any provided trailing metadata
+func echoTrailers(ctx context.Context) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		values := md.Get("showcase-trailer")
+		for _, value := range values {
+			trailer := metadata.Pairs("showcase-trailer", value)
+			grpc.SetTrailer(ctx, trailer)
+		}
+	}
+}
+
+func echoStreamingTrailers(stream grpc.ServerStream) {
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if ok {
+		values := md.Get("showcase-trailer")
+		for _, value := range values {
+			trailer := metadata.Pairs("showcase-trailer", value)
+			stream.SetTrailer(trailer)
+		}
+	}
 }

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -175,6 +175,7 @@ func echoTrailers(ctx context.Context) {
 	if !ok {
 		return
 	}
+
 	values := md.Get("showcase-trailer")
 	for _, value := range values {
 		trailer := metadata.Pairs("showcase-trailer", value)
@@ -187,6 +188,7 @@ func echoStreamingTrailers(stream grpc.ServerStream) {
 	if !ok {
 		return
 	}
+
 	values := md.Get("showcase-trailer")
 	for _, value := range values {
 		trailer := metadata.Pairs("showcase-trailer", value)

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -41,7 +41,8 @@ func TestEcho_success(t *testing.T) {
 	for _, val := range table {
 		in := &pb.EchoRequest{Response: &pb.EchoRequest_Content{Content: val}}
 		mockStream := &mockUnaryStream{t: t}
-		out, err := server.Echo(appendTestOutgoingMetadata(context.Background(), &mockSTS{t: t, stream: mockStream}), in)
+		ctx := appendTestOutgoingMetadata(context.Background(), &mockSTS{t: t, stream: mockStream})
+		out, err := server.Echo(ctx, in)
 		if err != nil {
 			t.Error(err)
 		}
@@ -55,7 +56,8 @@ func TestEcho_success(t *testing.T) {
 			Error: &spb.Status{Code: int32(codes.OK)}}}
 
 	mockStream := &mockUnaryStream{t: t}
-	_, err := server.Echo(appendTestOutgoingMetadata(context.Background(), &mockSTS{t: t, stream: mockStream}), in)
+	ctx := appendTestOutgoingMetadata(context.Background(), &mockSTS{t: t, stream: mockStream})
+	_, err := server.Echo(ctx, in)
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -471,8 +471,7 @@ func TestBlockError(t *testing.T) {
 }
 
 func appendTestOutgoingMetadata(ctx context.Context) context.Context {
-	ctx = metadata.AppendToOutgoingContext(ctx, "showcase-trailer", "show")
-	ctx = metadata.AppendToOutgoingContext(ctx, "showcase-trailer", "case")
+	ctx = metadata.AppendToOutgoingContext(ctx, "showcase-trailer", "show", "showcase-trailer", "case")
 	ctx = metadata.AppendToOutgoingContext(ctx, "trailer", "trail")
 	return ctx
 }

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -90,6 +90,10 @@ func (m *mockExpandStream) Send(resp *pb.EchoResponse) error {
 	return nil
 }
 
+func (m *mockExpandStream) Context() context.Context {
+	return context.Background()
+}
+
 func (m *mockExpandStream) verify() {
 	if len(m.exp) > 0 {
 		m.t.Errorf("Exand did not stream all expected values. %d expected values remaining.", len(m.exp))
@@ -161,6 +165,10 @@ func (m *mockCollectStream) Recv() (*pb.EchoRequest, error) {
 		return ret, nil
 	}
 	return nil, io.EOF
+}
+
+func (m *mockCollectStream) Context() context.Context {
+	return context.Background()
 }
 
 func TestCollect(t *testing.T) {
@@ -240,6 +248,10 @@ func (m *mockChatStream) Send(r *pb.EchoResponse) error {
 		m.curr = nil
 	}
 	return nil
+}
+
+func (m *mockChatStream) Context() context.Context {
+	return context.Background()
 }
 
 func TestChat(t *testing.T) {


### PR DESCRIPTION
This adds the ability for all echo services to echo the contents of the `showcase-trailer` metadata key to the response trailers. This is useful to ensure that any gapic helper code doesn't obscure access to trailing metadata across all method types.