### PR TITLE
fix: correct resource type for Blurb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             docker run --rm \
               --mount type=bind,source="$(pwd)"/api-common-protos,target=/proto \
               --mount type=bind,source="$(pwd)"/koutput,target=/generated \
-              gcr.io/kotlin-gapic/kgen:0.6.0
+              gcr.io/kotlin-gapic/kgen:0.6.1
 
   python-smoke-test:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             docker run --rm \
               --mount type=bind,source="$(pwd)"/api-common-protos,target=/proto \
               --mount type=bind,source="$(pwd)"/koutput,target=/generated \
-              gcr.io/kotlin-gapic/kgen:0.6.1
+              gcr.io/kotlin-gapic/kgen:0.6.0
 
   python-smoke-test:
     machine: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+### v0.6.1 / 2019-11-01
+- Fix the resource name for Blurb.
+
 ### v0.6.0 / 2019-11-01
 - Add a gRPC ServiceConfig for microgenerator retry config
 - Regen client code with retry config

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ page, or simply by installing from source using go.
 
 ### Docker
 ```sh
-$ docker pull gcr.io/gapic-images/gapic-showcase:0.6.0
+$ docker pull gcr.io/gapic-images/gapic-showcase:0.6.1
 $ docker run \
     --rm \
     -p 7469:7469/tcp \
     -p 7469:7469/udp \
-    gcr.io/gapic-images/gapic-showcase:0.6.0 \
+    gcr.io/gapic-images/gapic-showcase:0.6.1 \
     --help
 > Root command of gapic-showcase
 >
@@ -52,7 +52,7 @@ $ docker run \
 
 ### Binary
 ```sh
-$ export GAPIC_SHOWCASE_VERSION=0.6.0
+$ export GAPIC_SHOWCASE_VERSION=0.6.1
 $ export OS=linux
 $ export ARCH=amd64
 $ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH} | sudo tar -zx -- --directory /usr/local/bin/

--- a/cmd/gapic-showcase/version.go
+++ b/cmd/gapic-showcase/version.go
@@ -18,7 +18,7 @@ func init() {
 	// Make roots version option only emit the version. This is used in circleci.
 	// The template looks weird on purpose. Leaving as a single line causes the
 	// output to append an extra character.
-	rootCmd.Version = "0.6.0"
+	rootCmd.Version = "0.6.1"
 	rootCmd.SetVersionTemplate(
 		`{{printf "%s" .Version}}`)
 }

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -287,7 +287,7 @@ message ListRoomsResponse {
 // posted on a user profile.
 message Blurb {
   option (google.api.resource) = {
-    type: "google.showcase.com/Blurb"
+    type: "showcase.googleapis.com/Blurb"
     pattern: "rooms/{room_id}/blurbs/{blurb_id}"
     pattern: "user/{user_id}/profile/blurbs/{blurb_id}"
   };

--- a/util/cmd/bump_version/main.go
+++ b/util/cmd/bump_version/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const currentAPIVersion = "v1beta1"
-const currentReleaseVersion = "0.6.0"
+const currentReleaseVersion = "0.6.1"
 
 // This script updates the release version or API version of files in gapic-showcase.
 // This script is used on API and release version bumps. This script must be ran in


### PR DESCRIPTION
It's of course a little bit of a breaking change, but do we care here? It's an internal test library.