### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ docker run \
 $ export GAPIC_SHOWCASE_VERSION=0.6.1
 $ export OS=linux
 $ export ARCH=amd64
-$ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH} | sudo tar -zx -- --directory /usr/local/bin/
+$ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | sudo tar -zx --directory /usr/local/bin/
 $ gapic-showcase --help
 ...
 ```


### PR DESCRIPTION
Fix the Binary install command in the main readme.
- add the .tar.gz extension to the filepath
- fix the tar command