### PR TITLE
chore: update compile_protos to not be GOPATH based

### DIFF
--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -39,7 +39,7 @@ func CompileProtos(version string) {
 		log.Fatalf("Error: unable to get working dir: %+v", err)
 	}
 
-	outDir, err := ioutil.TempDir(os.TempDir(), "autogen")
+	outDir, err := ioutil.TempDir(os.TempDir(), "gapic-showcase")
 	if err != nil {
 		log.Fatalf("Error: unable to create a temporary dir: %+v\n", err)
 	}


### PR DESCRIPTION
Fixes #227 

CI is using Go 1.13 images, but still sets everything up in a `GOPATH`-type way. This is OK because the scripts can now be used locally with Go 1.13 to regen, print changes, etc.