### PR TITLE
chore: ensure go mod enabled in ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
     docker:
       - image: golang:1.13
     working_directory: /go/src/github.com/googleapis/gapic-showcase
+    environment:
+      GO111MODULE: "on"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,10 @@ jobs:
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/
       - run:
-          name: Get generators
+          name: Install generators
           command: |
-              go get github.com/golang/protobuf/protoc-gen-go
+              go mod download
+              go install github.com/golang/protobuf/protoc-gen-go
               go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_cli
               go get github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,9 @@ jobs:
           name: Examine and report suspicious constructs
           command: "! go tool vet ./ 2>&1 | read"
       - run:
+          name: Retrieve dependencies
+          command: go mod download
+      - run:
           name: Install gapic-showcase CLI
           command: go install ./cmd/gapic-showcase
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
           command: git submodule update --init
       - run:
           name: Retrieve dependencies
-          command: go get ./...
+          command: go mod download
       - run:
           name: Install protoc
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ jobs:
           name: Examine and report suspicious constructs
           command: "! go tool vet ./ 2>&1 | read"
       - run:
-          name: Install dependencies
-          command: go get -v -d -t ./cmd/gapic-showcase && go install ./cmd/gapic-showcase
+          name: Install gapic-showcase CLI
+          command: go install ./cmd/gapic-showcase
       - run:
           name: Run tests
           command: |


### PR DESCRIPTION
The CI scripts had not been updated in a while and were still using `go get` to install dependencies. This was also updating them in the same job, rather than respecting the `go.mod`. It creates regen PRs [like this](https://github.com/googleapis/gapic-showcase/pull/329) that update the `go.mod` and are using a newer version of `protoc-gen-go` than specified via `github.com/golang/protobuf` in the `go.mod`.

So we switch to `go mod download` to retrieve _build-time_ dependencies, and still use `go get` to retrieve generation-time dependencies (e.g. getting protoc-gen-go_gapic b.c it is not listed in the go.mod b.c it is not a build-time dependency for the server, client or cli).

In the case of `protoc-gen-go`, we want to respect the version of `github.com/golang/protobuf` specified in the `go.mod`, so we instead use `go install` to install the `protoc-gen-go` binary based on the downloaded version specified by `go.mod`.