### PR TITLE
fix: fix the typo in mtls logic

### DIFF
--- a/cmd/gapic-showcase/run.go
+++ b/cmd/gapic-showcase/run.go
@@ -69,7 +69,7 @@ func init() {
 			}
 
 			// load mutual TLS cert/key and root CA cert
-			if tlsCaCert == "" && tlsCert != "" && tlsKey != "" {
+			if tlsCaCert != "" && tlsCert != "" && tlsKey != "" {
 				keyPair, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
 				if err != nil {
 					log.Fatalf("Failed to load server TLS cert/key with error:%v", err)


### PR DESCRIPTION
I made a silly mistake, caught this problem when doing system tests.