### PR TITLE
chore: tidy go.mod in regen PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,8 @@ jobs:
           command: |
             # Exit early if no diff was found
             [[ ! -z ${DIFF_FOUND} ]] || exit 0
+            # Run go mod tidy to clean up added generation dependencies
+            go mod tidy
             # Setup git config.
             git config credential.helper 'cache --timeout=120'
             git config user.email "googleapis-publisher@google.com"


### PR DESCRIPTION
Run `go mod tidy` prior to opening a regeneration PR in order to prevent generation dependencies (e.g. gapic-generator-go) from being added as an indirect, like in [here](https://github.com/googleapis/gapic-showcase/pull/348/files#diff-37aff102a57d3d7b797f152915a6dc16R6).

Tested locally.