### PR TITLE
chore: bump CI protoc versrion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
-            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
+            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
             unzip ~/protoc3.zip -d ~/protoc3
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/


### PR DESCRIPTION
Upgrade protoc version used in CI & for automated regen to latest prior to next release.