### PR TITLE
chore: update regen tools for proto3_optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
-            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
+            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc1-linux-x86_64.zip
             unzip ~/protoc3.zip -d ~/protoc3
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
-            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc1-linux-x86_64.zip
+            curl -o ~/protoc3.zip -L https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc-1-linux-x86_64.zip
             unzip ~/protoc3.zip -d ~/protoc3
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/

--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -54,12 +54,17 @@ func CompileProtos(version string) {
 	// Run protoc
 	command := []string{
 		"protoc",
+		"--experimental_allow_proto3_optional",
 		"--proto_path=schema/api-common-protos",
 		"--proto_path=schema",
-		"--go_cli_out=" + filepath.Join("cmd", "gapic-showcase"),
-		"--go_cli_opt=root=gapic-showcase",
-		"--go_cli_opt=gapic=github.com/googleapis/gapic-showcase/client",
-		"--go_cli_opt=fmt=false",
+		// Disable go_cli generation until the generator supports it.
+		//
+		// TODO(ndietz): reenable once issue is resolved:
+		// https://github.com/googleapis/gapic-generator-go/issues/378
+		// "--go_cli_out=" + filepath.Join("cmd", "gapic-showcase"),
+		// "--go_cli_opt=root=gapic-showcase",
+		// "--go_cli_opt=gapic=github.com/googleapis/gapic-showcase/client",
+		// "--go_cli_opt=fmt=false",
 		"--go_gapic_out=" + outDir,
 		"--go_gapic_opt=go-gapic-package=github.com/googleapis/gapic-showcase/client;client",
 		"--go_gapic_opt=grpc-service-config=schema/google/showcase/v1beta1/showcase_grpc_service_config.json",


### PR DESCRIPTION
* Upgrade version of protoc used in CI to v3.12.0-rc1
* Add proto3_optional enablement flag to compile_protos
* Disable go_cli regen until it is updated to support proto3_optional until https://github.com/googleapis/gapic-generator-go/issues/378 is fixed and released
  * This is OK b.c nothing is changing in the client library that would affect the CLI, and the main use case for the CLI is just running the server. Thus the small change in the API surface isn't as urgent as getting `optional` integrated with gapic-showcase
  * When `optional` is integrated, a manual change to the CLI will be necessary b.c `optional` affects the code generated by `protoc-gen-go` and thus the `struct`s used by the CLI