### PR TITLE
chore: enable go_cli generation

### DIFF
--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -57,14 +57,10 @@ func CompileProtos(version string) {
 		"--experimental_allow_proto3_optional",
 		"--proto_path=schema/api-common-protos",
 		"--proto_path=schema",
-		// Disable go_cli generation until the generator supports it.
-		//
-		// TODO(ndietz): reenable once issue is resolved:
-		// https://github.com/googleapis/gapic-generator-go/issues/378
-		// "--go_cli_out=" + filepath.Join("cmd", "gapic-showcase"),
-		// "--go_cli_opt=root=gapic-showcase",
-		// "--go_cli_opt=gapic=github.com/googleapis/gapic-showcase/client",
-		// "--go_cli_opt=fmt=false",
+		"--go_cli_out=" + filepath.Join("cmd", "gapic-showcase"),
+		"--go_cli_opt=root=gapic-showcase",
+		"--go_cli_opt=gapic=github.com/googleapis/gapic-showcase/client",
+		"--go_cli_opt=fmt=false",
 		"--go_gapic_out=" + outDir,
 		"--go_gapic_opt=go-gapic-package=github.com/googleapis/gapic-showcase/client;client",
 		"--go_gapic_opt=grpc-service-config=schema/google/showcase/v1beta1/showcase_grpc_service_config.json",


### PR DESCRIPTION
https://github.com/googleapis/gapic-generator-go/issues/378 was closed and released in gapic-generator-go v0.14.1.

I tested everything locally, adding various uses of `optional` to verify the `go_cli` wouldn't generate a broken CLI.

CI should pull the latest release for generation and testing. This will show that it is backwards compatible. When a change is made to add `optional` to the showcase protos, we will need to include all new generated sources (pb.go, gapic and cli code) to properly test in CI.