### PR TITLE
Move a non-slash resource path to the top of Blurb's patterns

### DIFF
--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -288,11 +288,10 @@ message ListRoomsResponse {
 message Blurb {
   option (google.api.resource) = {
     type: "showcase.googleapis.com/Blurb"
+    pattern: "users/{user_id}/profile/blurbs/legacy/{legacy_user_id}~{blurb_id}"
+    pattern: "users/{user_id}/profile/blurbs/{blurb_id}"
     pattern: "rooms/{room_id}/blurbs/{blurb_id}"
     pattern: "rooms/{room_id}/blurbs/legacy/{legacy_room_id}.{blurb_id}"
-    pattern: "users/{user_id}/profile/blurbs/{blurb_id}"
-    pattern: "users/{user_id}/profile/blurbs/legacy/{legacy_user_id}~{blurb_id}"
-
   };
 
   // The resource name of the chat room.


### PR DESCRIPTION
Facilitates system tests in [gapic-generator-python](https://github.com/googleapis/gapic-generator-python/) on non-slash separated resource paths.