### PR TITLE
Fix update user response

### DIFF
--- a/server/services/identity_service.go
+++ b/server/services/identity_service.go
@@ -161,7 +161,7 @@ func (s *identityServerImpl) UpdateUser(_ context.Context, in *pb.UpdateUserRequ
 	}
 
 	s.users[i] = userEntry{user: updated}
-	return u, nil
+	return updated, nil
 }
 
 // Deletes a user, their profile, and all of their authored messages.

--- a/server/services/identity_service_test.go
+++ b/server/services/identity_service_test.go
@@ -95,6 +95,16 @@ func Test_User_lifecycle(t *testing.T) {
 	if err != nil {
 		t.Errorf("Update: unexpected err %+v", err)
 	}
+	// Ensure only those proto3_optional fields that were set got updated.
+	if updated.Age == nil {
+		t.Errorf("UpdateUser().Age was unexpectedly set to nil")
+	}
+	if updated.HeightFeet == nil {
+		t.Errorf("UpdateUser().HeightFeet was unexpectedly set to nil")
+	}
+	if updated.EnableNotifications == nil {
+		t.Errorf("UpdateUser().EnableNotifications was unexpectedly set to nil")
+	}
 
 	got, err = s.GetUser(
 		context.Background(),

--- a/server/services/identity_service_test.go
+++ b/server/services/identity_service_test.go
@@ -95,7 +95,7 @@ func Test_User_lifecycle(t *testing.T) {
 	if err != nil {
 		t.Errorf("Update: unexpected err %+v", err)
 	}
-	// Ensure only those proto3_optional fields that were set got updated.
+	// Ensure the proto3_optional fields that were unset did not get updated.
 	if updated.Age == nil {
 		t.Errorf("UpdateUser().Age was unexpectedly set to nil")
 	}


### PR DESCRIPTION
The `UpdateUser` handler was returning the `UpdateUserRequest.User` value, rather than the actual updated `User` resource stored in the in-mem DB. This was unnoticed previously, because all fields were directly updated with the contents of `UpdateUserRequest.User`. With the addition of `proto3_optional`, we only want to update those optional fields that are **set**. Because the `UpdateUserRequest.User` was returned (instead of the newly updated resource), unset values appear as `nil` in the response. When compared with the `User` retrieved via `GetUser`, the comparison failed. This changes `UpdateUser` to return the _updated `User` resource_, not the incoming patch.

Furthermore, we need to use copies of data in tests rather than direct responses, because the server uses an in-memory database. Previously, the `UpdateUserRequest.User` was set via the response of `GetUser`, and updated prior to making the RPC. Tweaking the `User` for an update actually updated the in-memory database of the server at the same time, rendering the test essentially useless.