### PR TITLE
release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### v0.10.1 / 2020-05-20
+- Fix UpdateUser handler response to send entire updated resource
+- Note: non-slash resource name changes are not included in this release
+
 ### v0.10.0 / 2020-05-18
 - Add use of proto3_optional in schema
 - Upgrade CI protoc to v3.12.0

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ page, or simply by installing from source using go.
 
 ### Docker
 ```sh
-$ docker pull gcr.io/gapic-images/gapic-showcase:0.10.0
+$ docker pull gcr.io/gapic-images/gapic-showcase:0.10.1
 $ docker run \
     --rm \
     -p 7469:7469/tcp \
     -p 7469:7469/udp \
-    gcr.io/gapic-images/gapic-showcase:0.10.0 \
+    gcr.io/gapic-images/gapic-showcase:0.10.1 \
     --help
 > Root command of gapic-showcase
 >
@@ -52,7 +52,7 @@ $ docker run \
 
 ### Binary
 ```sh
-$ export GAPIC_SHOWCASE_VERSION=0.10.0
+$ export GAPIC_SHOWCASE_VERSION=0.10.1
 $ export OS=linux
 $ export ARCH=amd64
 $ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | sudo tar -zx --directory /usr/local/bin/

--- a/cmd/gapic-showcase/version.go
+++ b/cmd/gapic-showcase/version.go
@@ -18,7 +18,7 @@ func init() {
 	// Make roots version option only emit the version. This is used in circleci.
 	// The template looks weird on purpose. Leaving as a single line causes the
 	// output to append an extra character.
-	rootCmd.Version = "0.10.0"
+	rootCmd.Version = "0.10.1"
 	rootCmd.SetVersionTemplate(
 		`{{printf "%s" .Version}}`)
 }

--- a/util/cmd/bump_version/main.go
+++ b/util/cmd/bump_version/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const currentAPIVersion = "v1beta1"
-const currentReleaseVersion = "0.10.0"
+const currentReleaseVersion = "0.10.1"
 
 // This script updates the release version or API version of files in gapic-showcase.
 // This script is used on API and release version bumps. This script must be ran in


### PR DESCRIPTION
Prepare a patch release that will pick #393 (and this commit) from `master` in order to avoid releasing non-slash resource names with this small fix.