### PR TITLE
test: test typescript in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ workflows:
           requires:
             - build
           filters: *all_commits
-      # TODO(fenster): https://github.com/googleapis/gapic-showcase/issues/383
-      # - typescript-smoke-test:
-      #     filters: *all_commits
+      - typescript-smoke-test:
+          filters: *all_commits
       # TODO(dovs): https://github.com/googleapis/gapic-showcase/issues/382
       # - python-smoke-test:
       #     filters: *all_commits
@@ -28,8 +27,7 @@ workflows:
       - github_release:
           requires:
             - test
-            # TODO(fenster): https://github.com/googleapis/gapic-showcase/issues/383
-            # - typescript-smoke-test
+            - typescript-smoke-test
             # TODO(dovs): https://github.com/googleapis/gapic-showcase/issues/382
             # - python-smoke-test
             - protobufjs-load-test
@@ -41,8 +39,7 @@ workflows:
       - push-image:
           requires:
             - test
-            # TODO(fenster): https://github.com/googleapis/gapic-showcase/issues/383
-            # - typescript-smoke-test
+            - typescript-smoke-test
             # TODO(dovs): https://github.com/googleapis/gapic-showcase/issues/382
             # - python-smoke-test
             - protobufjs-load-test


### PR DESCRIPTION
Fixes #383. Since gapic-generator-typescript now supports proto3 `optional`, re-enabling it in CI.