### PR TITLE
chore: remove release job from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -7,7 +7,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'ci/circleci: build'
     - 'ci/circleci: protobufjs-load-test'
-    - 'ci/circleci: push-generated-source'
     - 'ci/circleci: test'
     - 'ci/circleci: typescript-smoke-test'
     - 'cla/google'


### PR DESCRIPTION
The `push-generated-sources` job, which is part of our release system, was added as a required check. It isn't run on every PR.