### PR TITLE
feat: Add genrest to generated-source detection check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ jobs:
       - attach_workspace:
           at: /go
       - run:
-          name: Check if we are using generated source.
-          command: git diff --exit-code cmd client server/genproto || echo 'export DIFF_FOUND="true"' >> $BASH_ENV
+          name: Check whether we are using generated source.
+          command: git ls-files --deleted --modified --other --directory --exclude-standard cmd client server/genproto server/genrest | grep / && { echo 'export DIFF_FOUND="true"' >> $BASH_ENV ; }  || echo "No new generated files"
       - run:
           name: Check formatting
           command: "! gofmt -l ./ 2>&1 | read"
@@ -144,7 +144,7 @@ jobs:
       - attach_workspace:
           at: /go
       - run:
-          name: Check if we are using generated source.
+          name: Check whether we are using generated source.
           command: git diff --exit-code cmd client server/genproto || echo 'export DIFF_FOUND="true"' >> $BASH_ENV
       - run:
           name: Create pull request if diff is found.
@@ -245,7 +245,7 @@ jobs:
           command: |
             npm install google-proto-files
       - run:
-          name: Check if protos can be loaded by protobufjs
+          name: Check whether protos can be loaded by protobufjs
           command: |
             node -e "require('google-proto-files').loadSync('schema/google/showcase/v1beta1/echo.proto');"
             node -e "require('google-proto-files').loadSync('schema/google/showcase/v1beta1/identity.proto');"

--- a/util/genrest/genserver.go
+++ b/util/genrest/genserver.go
@@ -17,7 +17,6 @@ package genrest
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
@@ -32,8 +31,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 	resp.File = append(resp.File, &plugin.CodeGeneratorResponse_File{
 		Name: &fileName,
 		Content: proto.String(
-			fmt.Sprintf("Generated at %s\nFiles:\n%s",
-				time.Now().Format(time.UnixDate),
+			fmt.Sprintf("Files:\n%s",
 				strings.Join(genReq.FileToGenerate, "\n"))),
 	})
 	resp.SupportedFeatures = proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))


### PR DESCRIPTION
fix: Change the mechanism for generated source detection to use `git-ls-files` rather than `git-diff`. This allows capturing files that are not yet tracked by git (via the flag `--other`)
fix: Remove timestamp from `genrest` to avoid needless commits.