### PR TITLE
chore: Switch genrest plugin to use Go protobuf bindings v2

### DIFF
--- a/util/cmd/protoc-gen-go_rest_server/main.go
+++ b/util/cmd/protoc-gen-go_rest_server/main.go
@@ -15,12 +15,7 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
-	"os"
-
-	"github.com/golang/protobuf/proto"
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/googleapis/gapic-showcase/util/genrest"
 )
@@ -28,29 +23,8 @@ import (
 // TODO(vchudnov-g): Continue filling this in. It's a an initial empty
 // stub at the moment.
 func main() {
-	reqBytes, err := ioutil.ReadAll(os.Stdin)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen#Options
+	opts := &protogen.Options{}
+	opts.Run(genrest.Generate)
 
-	var genReq plugin.CodeGeneratorRequest
-	if err := proto.Unmarshal(reqBytes, &genReq); err != nil {
-		log.Fatal(err)
-	}
-
-	genResp, err := genrest.Gen(&genReq)
-	if err != nil {
-		genResp.Error = proto.String(err.Error())
-	}
-
-	outBytes, err := proto.Marshal(genResp)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if _, err := os.Stdout.Write(outBytes); err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf("Generated file: %q\n", *genResp.File[0].Name)
 }

--- a/util/genrest/genserver.go
+++ b/util/genrest/genserver.go
@@ -15,26 +15,22 @@
 package genrest
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // TODO(vchudnov-g): Continue filling this in. It's a an initial empty
 // stub at the moment.
-func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
-	fileName := "showcase-rest-sample-response.txt"
+func Generate(plugin *protogen.Plugin) error {
+	file := plugin.NewGeneratedFile("showcase-rest-sample-response.txt", "github.com/googleapis/gapic-showcase/server/genrest")
 
-	resp := &plugin.CodeGeneratorResponse{}
-	resp.File = append(resp.File, &plugin.CodeGeneratorResponse_File{
-		Name: &fileName,
-		Content: proto.String(
-			fmt.Sprintf("Files:\n%s",
-				strings.Join(genReq.FileToGenerate, "\n"))),
-	})
-	resp.SupportedFeatures = proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))
-
-	return resp, nil
+	// https://godoc.org/google.golang.org/protobuf/types/pluginpb
+	// The typecasting below appears to be idiomatic as per
+	// https: //github.com/protocolbuffers/protobuf-go/blob/master/cmd/protoc-gen-go/internal_gengo/main.go#L31
+	plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+	file.P("Generated via \"google.golang.org/protobuf/compiler/protogen\"")
+	file.P("Files:\n", strings.Join(plugin.Request.FileToGenerate, "\n"))
+	return nil
 }


### PR DESCRIPTION
The `genrest` protoc plug-in now depends on `google.golang.org/protobuf/compiler/protogen`, which provides a simpler
interface for implementing plug-ins.

More info:
- https://blog.golang.org/protobuf-apiv2
- https://pkg.go.dev/google.golang.org/protobuf@v1.25.0/compiler/protogen