### PR TITLE
feat: Serve gRPC and REST requests on the same external port

### DIFF
--- a/cmd/gapic-showcase/endpoint.go
+++ b/cmd/gapic-showcase/endpoint.go
@@ -1,0 +1,327 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/googleapis/gapic-showcase/server"
+	pb "github.com/googleapis/gapic-showcase/server/genproto"
+	"github.com/googleapis/gapic-showcase/server/services"
+	fallback "github.com/googleapis/grpc-fallback-go/server"
+	"github.com/soheilhy/cmux"
+	"golang.org/x/sync/errgroup"
+	lropb "google.golang.org/genproto/googleapis/longrunning"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
+)
+
+// RuntimeConfig has the run-time settings necessary to run the
+// Showcase servers.
+type RuntimeConfig struct {
+	port         string
+	fallbackPort string
+	tlsCaCert    string
+	tlsCert      string
+	tlsKey       string
+}
+
+// Endpoint defines common operations for any of the various types of
+// transport-specific network endpoints Showcase supports
+type Endpoint interface {
+	// Serve beings the listen-and-serve loop for this
+	// Endpoint. It typically blocks until the server is shut
+	// down. The error it returns depends on the underlying
+	// implementation.
+	Serve() error
+
+	// Shutdown causes the currently running Endpoint to
+	// terminate. The error it returns depends on the underlying
+	// implementation.
+	Shutdown() error
+}
+
+// CreateAllEndpoints returns an Endpoint that can serve gRPC and
+// HTTP/REST connections (on config.port) and gRPC-fallback
+// connections (on config.fallbackPort)
+func CreateAllEndpoints(config RuntimeConfig) Endpoint {
+	// Ensure port is of the right form.
+	if !strings.HasPrefix(config.port, ":") {
+		config.port = ":" + config.port
+	}
+
+	// Start listening.
+	lis, err := net.Listen("tcp", config.port)
+	if err != nil {
+		log.Fatalf("Showcase failed to listen on port '%s': %v", config.port, err)
+	}
+	stdLog.Printf("Showcase listening on port: %s", config.port)
+
+	m := cmux.New(lis)
+	grpcListener := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	httpListener := m.Match(cmux.HTTP1Fast())
+
+	gRPCServer := newEndpointGRPC(grpcListener, config)
+	restServer := newEndpointREST(httpListener)
+	cmuxServer := newEndpointMux(m, gRPCServer, restServer)
+	return cmuxServer
+}
+
+// endpointMux is an Endpoint for cmux, the connection multiplexer
+// allowing different types of connections on the same port.
+//
+// We choose not to use grpc.Server.ServeHTTP because it is
+// experimental and does not support some gRPC features available
+// through grpc.Server.Serve. (cf
+// https://godoc.org/google.golang.org/grpc#Server.ServeHTTP)
+type endpointMux struct {
+	endpoints []Endpoint
+	cmux      cmux.CMux
+	mux       sync.Mutex
+}
+
+func newEndpointMux(cmuxEndpoint cmux.CMux, endpoints ...Endpoint) Endpoint {
+	return &endpointMux{
+		endpoints: endpoints,
+		cmux:      cmuxEndpoint,
+	}
+}
+
+func (em *endpointMux) String() string {
+	return "endpoint multiplexer"
+}
+
+func (em *endpointMux) Serve() error {
+	g := new(errgroup.Group)
+	for idx, endpt := range em.endpoints {
+		if endpt != nil {
+			stdLog.Printf("Starting endpoint %d: %s", idx, endpt)
+			endpoint := endpt
+			g.Go(func() error {
+				err := endpoint.Serve()
+				err2 := em.Shutdown()
+				if err != nil {
+					return err
+				}
+				return err2
+			})
+		}
+	}
+	if em.cmux != nil {
+		stdLog.Printf("Starting %s", em)
+
+		g.Go(func() error {
+			err := em.cmux.Serve()
+			err2 := em.Shutdown()
+			if err != nil {
+				return err
+			}
+			return err2
+
+		})
+	}
+	return g.Wait()
+}
+
+func (em *endpointMux) Shutdown() error {
+	em.mux.Lock()
+	defer em.mux.Unlock()
+
+	var err error
+	if em.cmux != nil {
+		// TODO: Wait for https://github.com/soheilhy/cmux/pull/69 (due to
+		// https://github.com/soheilhy/cmux/pull/69#issuecomment-712928041.)
+		//
+		// err = em.mux.Close()
+		em.cmux = nil
+	}
+
+	for idx, endpt := range em.endpoints {
+		if endpt != nil {
+			// TODO: Wait for https://github.com/soheilhy/cmux/pull/69
+			// newErr := endpt.Shutdown()
+			// if err==nil {
+			// 	err = newErr
+			// }
+			em.endpoints[idx] = nil
+		}
+	}
+	return err
+}
+
+// endpointGRPC is an Endpoint for gRPC connections to the Showcase
+// server.
+type endpointGRPC struct {
+	server         *grpc.Server
+	fallbackServer *fallback.FallbackServer
+	listener       net.Listener
+	mux            sync.Mutex
+}
+
+func newEndpointGRPC(lis net.Listener, config RuntimeConfig) Endpoint {
+	// Set up server.
+	logger := &loggerObserver{}
+	observerRegistry := server.ShowcaseObserverRegistry()
+	observerRegistry.RegisterUnaryObserver(logger)
+	observerRegistry.RegisterStreamRequestObserver(logger)
+	observerRegistry.RegisterStreamResponseObserver(logger)
+
+	opts := []grpc.ServerOption{
+		grpc.StreamInterceptor(observerRegistry.StreamInterceptor),
+		grpc.UnaryInterceptor(observerRegistry.UnaryInterceptor),
+	}
+
+	// load mutual TLS cert/key and root CA cert
+	if config.tlsCaCert != "" && config.tlsCert != "" && config.tlsKey != "" {
+		keyPair, err := tls.LoadX509KeyPair(config.tlsCert, config.tlsKey)
+		if err != nil {
+			log.Fatalf("Failed to load server TLS cert/key with error:%v", err)
+		}
+
+		cert, err := ioutil.ReadFile(config.tlsCaCert)
+		if err != nil {
+			log.Fatalf("Failed to load root CA cert file with error:%v", err)
+		}
+
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(cert)
+
+		ta := credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{keyPair},
+			ClientCAs:    pool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+		})
+
+		opts = append(opts, grpc.Creds(ta))
+	}
+	s := grpc.NewServer(opts...)
+
+	// Creates services used by both the gRPC and REST servers
+	echoServer := services.NewEchoServer()
+
+	// Register Services to the server.
+	pb.RegisterEchoServer(s, echoServer)
+	pb.RegisterSequenceServiceServer(s, services.NewSequenceServer())
+	identityServer := services.NewIdentityServer()
+	pb.RegisterIdentityServer(s, identityServer)
+	messagingServer := services.NewMessagingServer(identityServer)
+	pb.RegisterMessagingServer(s, messagingServer)
+	operationsServer := services.NewOperationsServer(messagingServer)
+	pb.RegisterTestingServer(s, services.NewTestingServer(observerRegistry))
+	lropb.RegisterOperationsServer(s, operationsServer)
+
+	fb := fallback.NewServer(config.fallbackPort, "localhost"+config.port)
+
+	// Register reflection service on gRPC server.
+	reflection.Register(s)
+	return &endpointGRPC{
+		server:         s,
+		fallbackServer: fb,
+		listener:       lis,
+	}
+}
+
+func (eg *endpointGRPC) String() string {
+	return "gRPC endpoint"
+}
+
+func (eg *endpointGRPC) Serve() error {
+	defer eg.Shutdown()
+	if eg.fallbackServer != nil {
+		stdLog.Printf("Listening for gRPC-fallback connections")
+		eg.fallbackServer.StartBackground()
+	}
+	if eg.server != nil {
+		stdLog.Printf("Listening for gRPC connections")
+		return eg.server.Serve(eg.listener)
+	}
+	return fmt.Errorf("gRPC server not set up")
+}
+
+func (eg *endpointGRPC) Shutdown() error {
+	eg.mux.Lock()
+	defer eg.mux.Unlock()
+
+	if eg.fallbackServer != nil {
+		stdLog.Printf("Stopping gRPC-fallback connections")
+		eg.fallbackServer.Shutdown()
+		eg.fallbackServer = nil
+	}
+
+	if eg.server != nil {
+		stdLog.Printf("Stopping gRPC connections")
+		eg.server.GracefulStop()
+		eg.server = nil
+	}
+	stdLog.Printf("Stopped gRPC")
+	return nil
+}
+
+// endpointREST is an Endpoint for HTTP/REST connections to the Showcase
+// server.
+type endpointREST struct {
+	server   *http.Server
+	listener net.Listener
+	mux      sync.Mutex
+}
+
+func newEndpointREST(lis net.Listener) Endpoint {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("GAPIC Showcase: HTTP/REST endpoint\n"))
+	})
+
+	return &endpointREST{
+		server:   &http.Server{Handler: mux},
+		listener: lis,
+	}
+}
+
+func (er *endpointREST) String() string {
+	return "HTTP/REST endpoint"
+}
+
+func (er *endpointREST) Serve() error {
+	defer er.Shutdown()
+	if er.server != nil {
+		stdLog.Printf("Listening for REST connections")
+		return er.server.Serve(er.listener)
+	}
+	return fmt.Errorf("REST server not set up")
+}
+
+func (er *endpointREST) Shutdown() error {
+	er.mux.Lock()
+	defer er.mux.Unlock()
+	var err error
+	if er.server != nil {
+		stdLog.Printf("Stopping REST connections")
+		err = er.server.Shutdown(context.Background())
+		er.server = nil
+	}
+	stdLog.Printf("Stopped REST")
+	return err
+}

--- a/cmd/gapic-showcase/run.go
+++ b/cmd/gapic-showcase/run.go
@@ -15,155 +15,43 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
-	"log"
-	"net"
-	"net/http"
-	"strings"
+	"os"
+	"os/signal"
+	"syscall"
 
-	"golang.org/x/sync/errgroup"
-
-	"github.com/googleapis/gapic-showcase/server"
-	pb "github.com/googleapis/gapic-showcase/server/genproto"
-	"github.com/googleapis/gapic-showcase/server/services"
-	fallback "github.com/googleapis/grpc-fallback-go/server"
-	"github.com/soheilhy/cmux"
 	"github.com/spf13/cobra"
-	lropb "google.golang.org/genproto/googleapis/longrunning"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/reflection"
 )
 
-func grpcServe(lis net.Listener, config configuration) error {
-	// Setup Server.
-	logger := &loggerObserver{}
-	observerRegistry := server.ShowcaseObserverRegistry()
-	observerRegistry.RegisterUnaryObserver(logger)
-	observerRegistry.RegisterStreamRequestObserver(logger)
-	observerRegistry.RegisterStreamResponseObserver(logger)
-
-	opts := []grpc.ServerOption{
-		grpc.StreamInterceptor(observerRegistry.StreamInterceptor),
-		grpc.UnaryInterceptor(observerRegistry.UnaryInterceptor),
+func message(err error) string {
+	if err == nil {
+		return "ok"
 	}
-
-	// load mutual TLS cert/key and root CA cert
-	if config.tlsCaCert != "" && config.tlsCert != "" && config.tlsKey != "" {
-		keyPair, err := tls.LoadX509KeyPair(config.tlsCert, config.tlsKey)
-		if err != nil {
-			log.Fatalf("Failed to load server TLS cert/key with error:%v", err)
-		}
-
-		cert, err := ioutil.ReadFile(config.tlsCaCert)
-		if err != nil {
-			log.Fatalf("Failed to load root CA cert file with error:%v", err)
-		}
-
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(cert)
-
-		ta := credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{keyPair},
-			ClientCAs:    pool,
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-		})
-
-		opts = append(opts, grpc.Creds(ta))
-	}
-	s := grpc.NewServer(opts...)
-	defer s.GracefulStop()
-
-	// Creates services used by both the gRPC and REST servers
-	echoServer := services.NewEchoServer()
-
-	// Note: we may be able to share a port
-	// for handling gRPC and a regular HTTP
-	// port!
-	// https://godoc.org/google.golang.org/grpc#Server.ServeHTTP
-	// This has many limitations and is
-	// experimental, however. A better option:
-	// issue a 307 in the specified port if
-	// getting gRPC (as per the detection
-	// algorithm in the URL above)
-	// https://tools.ietf.org/html/rfc2616#page-65
-	// https://en.wikipedia.org/wiki/HTTP_302
-
-	// USE THIS: https://medium.com/@drgarcia1986/listen-grpc-and-http-requests-on-the-same-port-263c40cb45ff
-	// which employs cmux: https://github.com/soheilhy/cmux
-
-	// Register Services to the server.
-	pb.RegisterEchoServer(s, echoServer)
-	pb.RegisterSequenceServiceServer(s, services.NewSequenceServer())
-	identityServer := services.NewIdentityServer()
-	pb.RegisterIdentityServer(s, identityServer)
-	messagingServer := services.NewMessagingServer(identityServer)
-	pb.RegisterMessagingServer(s, messagingServer)
-	operationsServer := services.NewOperationsServer(messagingServer)
-	pb.RegisterTestingServer(s, services.NewTestingServer(observerRegistry))
-	lropb.RegisterOperationsServer(s, operationsServer)
-
-	fb := fallback.NewServer(config.fallbackPort, "localhost"+config.port)
-	fb.StartBackground()
-	defer fb.Shutdown()
-
-	// Register reflection service on gRPC server.
-	reflection.Register(s)
-	stdLog.Printf("  listening for gRPC connections")
-	return s.Serve(lis)
-}
-
-func httpServe(lis net.Listener, config configuration) error {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("GAPIC Showcase: HTTP/REST endpoint\n"))
-	})
-
-	s := &http.Server{Handler: mux}
-	stdLog.Printf("  listening for REST connections")
-	return s.Serve(lis)
-}
-
-type configuration struct {
-	port         string
-	fallbackPort string
-	tlsCaCert    string
-	tlsCert      string
-	tlsKey       string
+	return err.Error()
 }
 
 func init() {
-	config := configuration{}
+	config := RuntimeConfig{}
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Runs the showcase server",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Ensure port is of the right form.
-			if !strings.HasPrefix(config.port, ":") {
-				config.port = ":" + config.port
-			}
+			cmuxServer := CreateAllEndpoints(config)
 
-			// Start listening.
-			lis, err := net.Listen("tcp", config.port)
-			if err != nil {
-				log.Fatalf("Showcase failed to listen on port '%s': %v", config.port, err)
-			}
-			stdLog.Printf("Showcase listening on port: %s", config.port)
+			done := make(chan os.Signal, 2)
+			signal.Notify(done, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGSTOP)
+			go func() {
+				sig := <-done
+				stdLog.Printf("Got signal %q", sig)
+				stdLog.Printf("Shutting down server: %s", message(cmuxServer.Shutdown()))
 
-			m := cmux.New(lis)
-			grpcListener := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
-			httpListener := m.Match(cmux.HTTP1Fast())
+				// TODO: Delete the following line once this PR is
+				// merged: https://github.com/soheilhy/cmux/pull/69. The issue is
+				// that the user cannot Ctrl-C the main binary, probably due to
+				// https://github.com/soheilhy/cmux/pull/69#issuecomment-712928041.
+				os.Exit(1)
+			}()
 
-			g := new(errgroup.Group)
-			g.Go(func() error { return grpcServe(grpcListener, config) })
-			g.Go(func() error { return httpServe(httpListener, config) })
-			g.Go(func() error { return m.Serve() })
-
-			stdLog.Printf("after running server: %x\n", g.Wait())
-
+			stdLog.Printf("Server finished: %s", message(cmuxServer.Serve()))
 		},
 	}
 	rootCmd.AddCommand(runCmd)

--- a/cmd/gapic-showcase/run.go
+++ b/cmd/gapic-showcase/run.go
@@ -34,111 +34,140 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+func grpcServe(lis net.Listener, config configuration) error {
+	// Setup Server.
+	logger := &loggerObserver{}
+	observerRegistry := server.ShowcaseObserverRegistry()
+	observerRegistry.RegisterUnaryObserver(logger)
+	observerRegistry.RegisterStreamRequestObserver(logger)
+	observerRegistry.RegisterStreamResponseObserver(logger)
+
+	opts := []grpc.ServerOption{
+		grpc.StreamInterceptor(observerRegistry.StreamInterceptor),
+		grpc.UnaryInterceptor(observerRegistry.UnaryInterceptor),
+	}
+
+	// load mutual TLS cert/key and root CA cert
+	if config.tlsCaCert != "" && config.tlsCert != "" && config.tlsKey != "" {
+		keyPair, err := tls.LoadX509KeyPair(config.tlsCert, config.tlsKey)
+		if err != nil {
+			log.Fatalf("Failed to load server TLS cert/key with error:%v", err)
+		}
+
+		cert, err := ioutil.ReadFile(config.tlsCaCert)
+		if err != nil {
+			log.Fatalf("Failed to load root CA cert file with error:%v", err)
+		}
+
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(cert)
+
+		ta := credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{keyPair},
+			ClientCAs:    pool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+		})
+
+		opts = append(opts, grpc.Creds(ta))
+	}
+	s := grpc.NewServer(opts...)
+	defer s.GracefulStop()
+
+	// Creates services used by both the gRPC and REST servers
+	echoServer := services.NewEchoServer()
+
+	// Note: we may be able to share a port
+	// for handling gRPC and a regular HTTP
+	// port!
+	// https://godoc.org/google.golang.org/grpc#Server.ServeHTTP
+	// This has many limitations and is
+	// experimental, however. A better option:
+	// issue a 307 in the specified port if
+	// getting gRPC (as per the detection
+	// algorithm in the URL above)
+	// https://tools.ietf.org/html/rfc2616#page-65
+	// https://en.wikipedia.org/wiki/HTTP_302
+
+	// USE THIS: https://medium.com/@drgarcia1986/listen-grpc-and-http-requests-on-the-same-port-263c40cb45ff
+	// which employs cmux: https://github.com/soheilhy/cmux
+
+	// Register Services to the server.
+	pb.RegisterEchoServer(s, echoServer)
+	pb.RegisterSequenceServiceServer(s, services.NewSequenceServer())
+	identityServer := services.NewIdentityServer()
+	pb.RegisterIdentityServer(s, identityServer)
+	messagingServer := services.NewMessagingServer(identityServer)
+	pb.RegisterMessagingServer(s, messagingServer)
+	operationsServer := services.NewOperationsServer(messagingServer)
+	pb.RegisterTestingServer(s, services.NewTestingServer(observerRegistry))
+	lropb.RegisterOperationsServer(s, operationsServer)
+
+	fb := fallback.NewServer(config.fallbackPort, "localhost"+config.port)
+	fb.StartBackground()
+	defer fb.Shutdown()
+
+	// Register reflection service on gRPC server.
+	reflection.Register(s)
+	stdLog.Printf("  listening for gRPC connections")
+	return s.Serve(lis)
+
+}
+
+type configuration struct {
+	port         string
+	fallbackPort string
+	tlsCaCert    string
+	tlsCert      string
+	tlsKey       string
+}
+
 func init() {
-	var port string
-	var fallbackPort string
-	var tlsCaCert string
-	var tlsCert string
-	var tlsKey string
+	config := configuration{}
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Runs the showcase server",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Ensure port is of the right form.
-			if !strings.HasPrefix(port, ":") {
-				port = ":" + port
+			if !strings.HasPrefix(config.port, ":") {
+				config.port = ":" + config.port
 			}
 
 			// Start listening.
-			lis, err := net.Listen("tcp", port)
+			lis, err := net.Listen("tcp", config.port)
 			if err != nil {
-				log.Fatalf("Showcase failed to listen on port '%s': %v", port, err)
+				log.Fatalf("Showcase failed to listen on port '%s': %v", config.port, err)
 			}
-			stdLog.Printf("Showcase listening on port: %s", port)
+			stdLog.Printf("Showcase listening on port: %s", config.port)
 
-			// Setup Server.
-			logger := &loggerObserver{}
-			observerRegistry := server.ShowcaseObserverRegistry()
-			observerRegistry.RegisterUnaryObserver(logger)
-			observerRegistry.RegisterStreamRequestObserver(logger)
-			observerRegistry.RegisterStreamResponseObserver(logger)
+			grpcServe(lis, config)
 
-			opts := []grpc.ServerOption{
-				grpc.StreamInterceptor(observerRegistry.StreamInterceptor),
-				grpc.UnaryInterceptor(observerRegistry.UnaryInterceptor),
-			}
-
-			// load mutual TLS cert/key and root CA cert
-			if tlsCaCert != "" && tlsCert != "" && tlsKey != "" {
-				keyPair, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-				if err != nil {
-					log.Fatalf("Failed to load server TLS cert/key with error:%v", err)
-				}
-
-				cert, err := ioutil.ReadFile(tlsCaCert)
-				if err != nil {
-					log.Fatalf("Failed to load root CA cert file with error:%v", err)
-				}
-
-				pool := x509.NewCertPool()
-				pool.AppendCertsFromPEM(cert)
-
-				ta := credentials.NewTLS(&tls.Config{
-					Certificates: []tls.Certificate{keyPair},
-					ClientCAs:    pool,
-					ClientAuth:   tls.RequireAndVerifyClientCert,
-				})
-
-				opts = append(opts, grpc.Creds(ta))
-			}
-			s := grpc.NewServer(opts...)
-			defer s.GracefulStop()
-
-			// Register Services to the server.
-			pb.RegisterEchoServer(s, services.NewEchoServer())
-			pb.RegisterSequenceServiceServer(s, services.NewSequenceServer())
-			identityServer := services.NewIdentityServer()
-			pb.RegisterIdentityServer(s, identityServer)
-			messagingServer := services.NewMessagingServer(identityServer)
-			pb.RegisterMessagingServer(s, messagingServer)
-			operationsServer := services.NewOperationsServer(messagingServer)
-			pb.RegisterTestingServer(s, services.NewTestingServer(observerRegistry))
-			lropb.RegisterOperationsServer(s, operationsServer)
-
-			fb := fallback.NewServer(fallbackPort, "localhost"+port)
-			fb.StartBackground()
-			defer fb.Shutdown()
-
-			// Register reflection service on gRPC server.
-			reflection.Register(s)
-			s.Serve(lis)
 		},
 	}
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringVarP(
-		&port,
+		&config.port,
 		"port",
 		"p",
 		":7469",
 		"The port that showcase will be served on.")
 	runCmd.Flags().StringVarP(
-		&fallbackPort,
+		&config.fallbackPort,
 		"fallback-port",
 		"f",
 		":1337",
 		"The port that the fallback-proxy will be served on.")
 	runCmd.Flags().StringVar(
-		&tlsCaCert,
+		&config.tlsCaCert,
 		"mtls-ca-cert",
 		"",
 		"The Root CA certificate path for custom mutual TLS channel.")
 	runCmd.Flags().StringVar(
-		&tlsCert,
+		&config.tlsCert,
 		"mtls-cert",
 		"",
 		"The server certificate path for custom mutual TLS channel.")
 	runCmd.Flags().StringVar(
-		&tlsKey,
+		&config.tlsKey,
 		"mtls-key",
 		"",
 		"The server private key path for custom mutual TLS channel.")

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/googleapis/grpc-fallback-go v0.1.4
+	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	google.golang.org/api v0.33.0
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154
 	google.golang.org/grpc v1.33.1

--- a/util/genrest/genserver.go
+++ b/util/genrest/genserver.go
@@ -28,7 +28,7 @@ func Generate(plugin *protogen.Plugin) error {
 
 	// https://godoc.org/google.golang.org/protobuf/types/pluginpb
 	// The typecasting below appears to be idiomatic as per
-	// https: //github.com/protocolbuffers/protobuf-go/blob/master/cmd/protoc-gen-go/internal_gengo/main.go#L31
+	// https://github.com/protocolbuffers/protobuf-go/blob/master/cmd/protoc-gen-go/internal_gengo/main.go#L31
 	plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 	file.P("Generated via \"google.golang.org/protobuf/compiler/protogen\"")
 	file.P("Files:\n", strings.Join(plugin.Request.FileToGenerate, "\n"))


### PR DESCRIPTION
This PR uses the cmux package to expose a single external port that selects incoming connections to route to the gRPC endpoint or the REST endpoint.
(ref: https://medium.com/@drgarcia1986/listen-grpc-and-http-requests-on-the-same-port-263c40cb45ff and https://github.com/soheilhy/cmux)

I define an Endpoint interface wrapping both the gRPC and the REST endpoints, as well as the cmux multiplexer that does the redirection. This infrastructure will also allow future endpoints to be easily added when we need them.

This also sets up the infrastructure for graceful shutdown upon receipt of a signal, though we are waiting for a PR in the cmux dependency for that to work fully. (The issue is described in https://github.com/soheilhy/cmux/pull/69#issuecomment-712928041.)

Implementation/review notes:
- the gRPC server set-up code is now in `cmd/gapic-showcase/endpoint.go`. It is split between setting up the server and running it.
- the REST server (also in `endpoint.go`) is currently a stub that simply responds to `/hello` requests. It will be expanded with auto-generated handlers.

