### PR TITLE
fix(genrest): adopt strict JSON semantics for bool values

### DIFF
--- a/util/genrest/gomodel/gomodel.go
+++ b/util/genrest/gomodel/gomodel.go
@@ -170,10 +170,6 @@ type RESTHandler struct {
 	StreamingServer bool         // whether this method uses server-side streaming
 	StreamingClient bool         // whether this method uses client-side streaming
 
-	// TODO: Fill in with actual information needed to access each field. These are placeholders
-	// for now.
-	PathFields, QueryFields, BodyFields []*interface{}
-
 	//// Go types
 
 	GoMethod                  string

--- a/util/genrest/resttools/populatefield.go
+++ b/util/genrest/resttools/populatefield.go
@@ -142,9 +142,7 @@ func PopulateOneField(protoMessage proto.Message, fieldPath string, fieldValues 
 			parseError, protoValue = err, protoreflect.ValueOfFloat64(parsedValue)
 
 		case protoreflect.BoolKind:
-			// TODO: should we be stricter in what we accept? ParseBool accepts various
-			// representations of "true" and "false" (https://golang.org/pkg/strconv/#ParseBool)
-			parsedValue, err := strconv.ParseBool(value)
+			parsedValue, err := parseBool(value)
 			parseError, protoValue = err, protoreflect.ValueOfBool(parsedValue)
 
 		default:
@@ -160,4 +158,18 @@ func PopulateOneField(protoMessage proto.Message, fieldPath string, fieldValues 
 	}
 
 	return nil
+}
+
+// parseBool parses a proper JSON representation of a bool value (either of the strings "true" or
+// "false") into a bool data type. Other values cause an error. These are stricter parsing semantics
+// than those of strconv.ParseBool and adhere to the JSON standard.
+func parseBool(asString string) (bool, error) {
+	switch asString {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("could not parse %q as a bool", asString)
+	}
 }

--- a/util/genrest/resttools/populatefield_test.go
+++ b/util/genrest/resttools/populatefield_test.go
@@ -253,3 +253,27 @@ func TestPopulateFields(t *testing.T) {
 
 	}
 }
+
+func TestParseBool(t *testing.T) {
+	for idx, testCase := range []struct {
+		asString    string
+		expectValue bool
+		expectError bool
+	}{
+		{"true", true, false},
+		{"false", false, false},
+		{"True", false, true},
+		{"False", false, true},
+		{"0", false, true},
+		{"1", false, true},
+	} {
+		val, err := parseBool(testCase.asString)
+		if got, want := (err != nil), testCase.expectError; got != want {
+			t.Errorf("test case %d[%q] error: got %v, want %v", idx, testCase.asString, err, want)
+			continue
+		}
+		if got, want := val, testCase.expectValue; got != want {
+			t.Errorf("test case %d[%q] got: %v,   want: %v", idx, testCase.asString, got, want)
+		}
+	}
+}

--- a/util/genrest/resttools/populatefield_test.go
+++ b/util/genrest/resttools/populatefield_test.go
@@ -137,7 +137,7 @@ func TestPopulateSingularFields(t *testing.T) {
 				"f_int32":                  "5",
 				"subpack.subpack.f_double": "53.47",
 				"subpack.subpack.f_int32":  "-6",
-				"subpack.f_bool":           "1", // NOTE: this gets parsed as "true"
+				"subpack.f_bool":           "true",
 			},
 			expectProtoText: `subpack:{subpack:{f_string:"lexicon" f_int32:-6 f_double:53.47} f_bool:true} f_string:"alphabet" f_int32:5`,
 		},
@@ -170,7 +170,7 @@ func TestPopulateSingularFields(t *testing.T) {
 				"p_string": "",
 				"p_int32":  "0",
 				"p_double": "0",
-				"p_bool":   "0", // NOTE: this gets parsed as "false"
+				"p_bool":   "false",
 			},
 			expectProtoText: `p_string:""  p_int32:0  p_double:0  p_bool:false`,
 		},


### PR DESCRIPTION
- We only accept the strings `"true"` and `"false"` now
- Also some minor cruft cleanup

(This reduces the `TODO` count by 2!)