### PR TITLE
chore: throttle googleapis bazel dep update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "labels": ["automerge"],
   "packageRules": [
     {
-      "packageNames": ["google.golang.org/genproto"],
+      "packageNames": ["google.golang.org/genproto", "com_google_googleapis"],
       "schedule": "after 12pm on monday"
     }
   ],


### PR DESCRIPTION
Scheduling update of googleapis to once per week, since it gets multiple commits per day and the protos depended upon by this project rarely change.