### PR TITLE
chore: update the other protoc in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           name: Install protoc
           command: |
             apt-get update && apt-get install -y unzip
-            curl -o ~/protoc3.zip -L https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-linux-x86_64.zip
+            curl -o ~/protoc3.zip -L https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip
             unzip ~/protoc3.zip -d ~/protoc3
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/


### PR DESCRIPTION
I forgot to change the other version protoc in the CI config. This one is used for the regen job.