### PR TITLE
feat: add location & iam mixin services

### DIFF
--- a/cmd/gapic-showcase/endpoint.go
+++ b/cmd/gapic-showcase/endpoint.go
@@ -34,6 +34,8 @@ import (
 	gmux "github.com/gorilla/mux"
 	"github.com/soheilhy/cmux"
 	"golang.org/x/sync/errgroup"
+	locpb "google.golang.org/genproto/googleapis/cloud/location"
+	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	lropb "google.golang.org/genproto/googleapis/longrunning"
 
 	"google.golang.org/grpc"
@@ -202,6 +204,8 @@ func createBackends() *services.Backend {
 		ComplianceServer:      services.NewComplianceServer(),
 		TestingServer:         services.NewTestingServer(observerRegistry),
 		OperationsServer:      services.NewOperationsServer(messagingServer),
+		LocationsServer:       services.NewLocationsServer(),
+		IAMPolicyServer:       services.NewIAMPolicyServer(),
 		StdLog:                stdLog,
 		ErrLog:                errLog,
 		ObserverRegistry:      observerRegistry,
@@ -245,8 +249,10 @@ func newEndpointGRPC(lis net.Listener, config RuntimeConfig, backend *services.B
 	pb.RegisterIdentityServer(s, backend.IdentityServer)
 	pb.RegisterMessagingServer(s, backend.MessagingServer)
 	pb.RegisterComplianceServer(s, backend.ComplianceServer)
-	lropb.RegisterOperationsServer(s, backend.OperationsServer)
 	pb.RegisterTestingServer(s, backend.TestingServer)
+	lropb.RegisterOperationsServer(s, backend.OperationsServer)
+	locpb.RegisterLocationsServer(s, backend.LocationsServer)
+	iampb.RegisterIAMPolicyServer(s, backend.IAMPolicyServer)
 
 	fb := fallback.NewServer(config.fallbackPort, "localhost"+config.port)
 

--- a/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -1,0 +1,71 @@
+type: google.api.Service
+config_version: 3
+name: showcase.googleapis.com
+title: The Client Libraries Showcase API
+
+apis:
+- name: google.showcase.v1beta1.Compliance
+- name: google.showcase.v1beta1.Echo
+- name: google.showcase.v1beta1.Identity
+- name: google.showcase.v1beta1.Messaging
+- name: google.showcase.v1beta1.SequenceService
+- name: google.showcase.v1beta1.Testing
+# Mix-in services
+- name: 'google.cloud.location.Locations'
+- name: 'google.iam.v1.IAMPolicy'
+- name: 'google.longrunning.Operations'
+
+documentation:
+  summary: |-
+    Showcase represents both a model API and an integration testing surface for
+    client library generator consumption.
+
+backend:
+  rules:
+  - selector: 'google.cloud.location.Locations.*'
+    deadline: 60.0
+  - selector: 'google.iam.v1.IAMPolicy.*'
+    deadline: 60.0
+  - selector: 'google.longrunning.Operations.*'
+    deadline: 60.0
+    
+http:
+  rules:
+  - selector: google.cloud.location.Locations.ListLocations
+    get:  '/v1beta1/{name=projects/*}/locations'
+  - selector: google.cloud.location.Locations.GetLocation
+    get:  '/v1beta1/{name=projects/*/locations/*}'
+  - selector: google.iam.v1.IAMPolicy.SetIamPolicy
+    post: '/v1beta1/{resource=users/*}:setIamPolicy'
+    body: '*'
+    additional_bindings:
+    - post: '/v1beta1/{resource=rooms/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1beta1/{resource=rooms/*/blurbs/*}:setIamPolicy'
+      body: '*'
+    - post: '/v1beta1/{resource=sequences/*}:setIamPolicy'
+      body: '*'
+  - selector: google.iam.v1.IAMPolicy.GetIamPolicy
+    get: '/v1beta1/{resource=users/*}:getIamPolicy'
+    additional_bindings:
+    - get: '/v1beta1/{resource=rooms/*}:getIamPolicy'
+    - get: '/v1beta1/{resource=rooms/*/blurbs/*}:getIamPolicy'
+    - get: '/v1beta1/{resource=sequences/*}:getIamPolicy'
+  - selector: google.iam.v1.IAMPolicy.TestIamPermissions
+    post: '/v1beta1/{resource=users/*}:testIamPermissions'
+    body: '*'
+    additional_bindings:
+    - post: '/v1beta1/{resource=rooms/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1beta1/{resource=rooms/*/blurbs/*}:testIamPermissions'
+      body: '*'
+    - post: '/v1beta1/{resource=sequences/*}:testIamPermissions'
+      body: '*'
+  - selector: google.longrunning.Operations.ListOperations
+    get: '/v1beta1/operations'
+  - selector: google.longrunning.Operations.GetOperation
+    get: '/v1beta1/{name=/operations/*}'
+  - selector: google.longrunning.Operations.DeleteOperation
+    delete: '/v1beta1/{name=/operations/*}'
+  - selector: google.longrunning.Operations.CancelOperation
+    post: '/v1beta1/{name=/operations/*}:cancel'

--- a/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -1,7 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 type: google.api.Service
 config_version: 3
 name: showcase.googleapis.com
-title: The Client Libraries Showcase API
+title: Client Libraries Showcase API
 
 apis:
 - name: google.showcase.v1beta1.Compliance

--- a/server/services/iam_policy_service.go
+++ b/server/services/iam_policy_service.go
@@ -1,0 +1,96 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	iampb "google.golang.org/genproto/googleapis/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var missingResource error = status.Error(codes.InvalidArgument, "Missing required argument: resource")
+var missingPolicy error = status.Error(codes.InvalidArgument, "Missing required argument: policy")
+var resourceDNE error = status.Error(codes.NotFound, "Requested resource has no Policy")
+
+// NewIAMPolicyServer returns a new LocationsServer for the Showcase API.
+func NewIAMPolicyServer() iampb.IAMPolicyServer {
+	return &iamPolicyServerImpl{
+		policies: map[string]*iampb.Policy{},
+	}
+}
+
+type iamPolicyServerImpl struct {
+	mu       sync.Mutex
+	policies map[string]*iampb.Policy
+}
+
+// GetIamPolicy retrieves the Policy for the named resource, if it has one.
+func (i *iamPolicyServerImpl) GetIamPolicy(ctx context.Context, in *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	if in.GetResource() == "" {
+		return nil, missingResource
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	p, ok := i.policies[in.GetResource()]
+	if !ok {
+		return nil, resourceDNE
+	}
+	res := proto.Clone(p)
+
+	return res.(*iampb.Policy), nil
+}
+
+// SetIamPolicy assigns the given Policy to the resource.
+func (i *iamPolicyServerImpl) SetIamPolicy(ctx context.Context, in *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	if in.GetResource() == "" {
+		return nil, missingResource
+	}
+	if in.GetPolicy() == nil {
+		return nil, missingPolicy
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	clone := proto.Clone(in.GetPolicy())
+	p := clone.(*iampb.Policy)
+	i.policies[in.GetResource()] = p
+
+	return in.GetPolicy(), nil
+}
+
+// TestIamPermissions verifies that the requested resource has been Set at one point, and echos the back permissions to be tested.
+func (i *iamPolicyServerImpl) TestIamPermissions(ctx context.Context, in *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	if in.GetResource() == "" {
+		return nil, missingResource
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, ok := i.policies[in.GetResource()]; !ok {
+		return nil, resourceDNE
+	}
+
+	return &iampb.TestIamPermissionsResponse{
+		Permissions: in.GetPermissions(),
+	}, nil
+}

--- a/server/services/iam_policy_service_test.go
+++ b/server/services/iam_policy_service_test.go
@@ -1,0 +1,152 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	iampb "google.golang.org/genproto/googleapis/iam/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestIamPolicySetGetTest(t *testing.T) {
+	s := NewIAMPolicyServer()
+
+	resource := "projects/myproject/foos/foo123"
+	policy := &iampb.Policy{
+		Version: 1,
+		Bindings: []*iampb.Binding{
+			{Role: "project/fooEditor"},
+		},
+	}
+	permissions := []string{"foo.write", "foo.read"}
+
+	p, err := s.SetIamPolicy(context.Background(), &iampb.SetIamPolicyRequest{Resource: resource, Policy: policy})
+	if err != nil {
+		t.Errorf("TestIamPolicySetGetTest > SetIamPolicy: unexpected error %q", err)
+	}
+
+	if diff := cmp.Diff(p, policy, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Errorf("TestIamPolicySetGetTest > SetIamPolicy: got(-),want(+):\n%s", diff)
+	}
+
+	p, err = s.GetIamPolicy(context.Background(), &iampb.GetIamPolicyRequest{Resource: resource})
+	if err != nil {
+		t.Errorf("TestIamPolicySetGetTest > GetIamPolicy: unexpected error %q", err)
+	}
+
+	if diff := cmp.Diff(p, policy, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Errorf("TestIamPolicySetGetTest > GetIamPolicy: got(-),want(+):\n%s", diff)
+	}
+
+	res, err := s.TestIamPermissions(context.Background(), &iampb.TestIamPermissionsRequest{
+		Resource:    resource,
+		Permissions: permissions,
+	})
+	if err != nil {
+		t.Errorf("TestIamPolicySetGetTest > TestIamPermissions: unexpected error %q", err)
+	}
+
+	if diff := cmp.Diff(res.Permissions, permissions); diff != "" {
+		t.Errorf("TestIamPolicySetGetTest > TestIamPermissions: got(-),want(+):\n%s", diff)
+	}
+}
+
+func TestGetIamPolicy_errors(t *testing.T) {
+	s := NewIAMPolicyServer()
+
+	for _, tst := range []struct {
+		name, resource string
+		err            error
+	}{
+		{
+			name: "missing resource field",
+			err:  missingResource,
+		},
+		{
+			name:     "resource does not exist",
+			resource: "foo/bar",
+			err:      resourceDNE,
+		},
+	} {
+		res, err := s.GetIamPolicy(context.Background(), &iampb.GetIamPolicyRequest{Resource: tst.resource})
+		if err != nil {
+			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("GetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
+			}
+		} else {
+			t.Errorf("GetIamPolicy_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+	}
+}
+
+func TestSetIamPolicy_errors(t *testing.T) {
+	s := NewIAMPolicyServer()
+
+	for _, tst := range []struct {
+		name, resource string
+		err            error
+	}{
+		{
+			name: "missing resource field",
+			err:  missingResource,
+		},
+		{
+			name:     "missing policy field",
+			resource: "foo/bar",
+			err:      missingPolicy,
+		},
+	} {
+		res, err := s.SetIamPolicy(context.Background(), &iampb.SetIamPolicyRequest{Resource: tst.resource})
+		if err != nil {
+			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("SetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
+			}
+		} else {
+			t.Errorf("SetIamPolicy_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+	}
+}
+
+func TestTestIamPermissions_errors(t *testing.T) {
+	s := NewIAMPolicyServer()
+
+	for _, tst := range []struct {
+		name, resource string
+		err            error
+	}{
+		{
+			name: "missing resource field",
+			err:  missingResource,
+		},
+		{
+			name:     "resource does not exist",
+			resource: "foo/bar",
+			err:      resourceDNE,
+		},
+	} {
+		res, err := s.TestIamPermissions(context.Background(), &iampb.TestIamPermissionsRequest{Resource: tst.resource})
+		if err != nil {
+			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("TestIamPermissions_errors(%s): got(-),want(+):\n%s", tst.name, diff)
+			}
+		} else {
+			t.Errorf("TestIamPermissions_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+	}
+}

--- a/server/services/iam_policy_service_test.go
+++ b/server/services/iam_policy_service_test.go
@@ -81,16 +81,16 @@ func TestGetIamPolicy_errors(t *testing.T) {
 		{
 			name:     "resource does not exist",
 			resource: "foo/bar",
-			err:      resourceDNE,
+			err:      resourceDoesNotExist,
 		},
 	} {
 		res, err := s.GetIamPolicy(context.Background(), &iampb.GetIamPolicyRequest{Resource: tst.resource})
-		if err != nil {
-			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("GetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
-			}
-		} else {
+		if err == nil {
 			t.Errorf("GetIamPolicy_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+
+		if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("GetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
 		}
 	}
 }
@@ -113,12 +113,12 @@ func TestSetIamPolicy_errors(t *testing.T) {
 		},
 	} {
 		res, err := s.SetIamPolicy(context.Background(), &iampb.SetIamPolicyRequest{Resource: tst.resource})
-		if err != nil {
-			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("SetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
-			}
-		} else {
+		if err == nil {
 			t.Errorf("SetIamPolicy_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+
+		if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("SetIamPolicy_errors(%s): got(-),want(+):\n%s", tst.name, diff)
 		}
 	}
 }
@@ -137,16 +137,16 @@ func TestTestIamPermissions_errors(t *testing.T) {
 		{
 			name:     "resource does not exist",
 			resource: "foo/bar",
-			err:      resourceDNE,
+			err:      resourceDoesNotExist,
 		},
 	} {
 		res, err := s.TestIamPermissions(context.Background(), &iampb.TestIamPermissionsRequest{Resource: tst.resource})
-		if err != nil {
-			if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("TestIamPermissions_errors(%s): got(-),want(+):\n%s", tst.name, diff)
-			}
-		} else {
+		if err == nil {
 			t.Errorf("TestIamPermissions_errors(%s): expected an error but got response: %v", tst.name, res)
+		}
+
+		if diff := cmp.Diff(err, tst.err, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("TestIamPermissions_errors(%s): got(-),want(+):\n%s", tst.name, diff)
 		}
 	}
 }

--- a/server/services/locations_service.go
+++ b/server/services/locations_service.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"strings"
+
+	locpb "google.golang.org/genproto/googleapis/cloud/location"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var missingName error = status.Error(codes.InvalidArgument, "Missing required argument: name")
+
+// NewLocationsServer returns a new LocationsServer for the Showcase API.
+func NewLocationsServer() locpb.LocationsServer {
+	return &locationsServerImpl{}
+}
+
+type locationsServerImpl struct{}
+
+// GetLocation echos back a Location with the same name as
+// GetLocationRequest.name and has the last segment of name as the display_name.
+func (l *locationsServerImpl) GetLocation(ctx context.Context, in *locpb.GetLocationRequest) (*locpb.Location, error) {
+	if in.GetName() == "" {
+		return nil, missingName
+	}
+
+	name := in.GetName()
+	display := name[strings.LastIndex(name, "/"):+1]
+
+	return &locpb.Location{
+		Name:        name,
+		DisplayName: display,
+	}, nil
+}
+
+// ListLocations returns a fixed list of Locations prefixed with the
+// ListLocationsRequest.name value.
+func (l *locationsServerImpl) ListLocations(ctx context.Context, in *locpb.ListLocationsRequest) (*locpb.ListLocationsResponse, error) {
+	if in.GetName() == "" {
+		return nil, missingName
+	}
+
+	return &locpb.ListLocationsResponse{
+		Locations: []*locpb.Location{
+			{
+				Name:        in.GetName() + "/locations/us-north",
+				DisplayName: "us-north",
+			},
+			{
+				Name:        in.GetName() + "/locations/us-south",
+				DisplayName: "us-south",
+			},
+			{
+				Name:        in.GetName() + "/locations/us-east",
+				DisplayName: "us-east",
+			},
+			{
+				Name:        in.GetName() + "/locations/us-west",
+				DisplayName: "us-west",
+			},
+		},
+	}, nil
+}

--- a/server/services/locations_service.go
+++ b/server/services/locations_service.go
@@ -40,7 +40,7 @@ func (l *locationsServerImpl) GetLocation(ctx context.Context, in *locpb.GetLoca
 	}
 
 	name := in.GetName()
-	display := name[strings.LastIndex(name, "/"):+1]
+	display := name[strings.LastIndex(name, "/")+1:]
 
 	return &locpb.Location{
 		Name:        name,

--- a/server/services/locations_service.go
+++ b/server/services/locations_service.go
@@ -32,8 +32,8 @@ func NewLocationsServer() locpb.LocationsServer {
 
 type locationsServerImpl struct{}
 
-// GetLocation echos back a Location with the same name as
-// GetLocationRequest.name and has the last segment of name as the display_name.
+// GetLocation echoes back a Location with the same name as
+// in.name and has the last segment of name as the display_name.
 func (l *locationsServerImpl) GetLocation(ctx context.Context, in *locpb.GetLocationRequest) (*locpb.Location, error) {
 	if in.GetName() == "" {
 		return nil, missingName
@@ -49,7 +49,7 @@ func (l *locationsServerImpl) GetLocation(ctx context.Context, in *locpb.GetLoca
 }
 
 // ListLocations returns a fixed list of Locations prefixed with the
-// ListLocationsRequest.name value.
+// in.name value.
 func (l *locationsServerImpl) ListLocations(ctx context.Context, in *locpb.ListLocationsRequest) (*locpb.ListLocationsResponse, error) {
 	if in.GetName() == "" {
 		return nil, missingName

--- a/server/services/locations_service_test.go
+++ b/server/services/locations_service_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	locpb "google.golang.org/genproto/googleapis/cloud/location"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestListLocations(t *testing.T) {
+	s := NewLocationsServer()
+	foo := "projects/foo"
+
+	got, err := s.ListLocations(context.Background(), &locpb.ListLocationsRequest{Name: foo})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := &locpb.ListLocationsResponse{
+		Locations: []*locpb.Location{
+			{
+				Name:        foo + "/locations/us-north",
+				DisplayName: "us-north",
+			},
+			{
+				Name:        foo + "/locations/us-south",
+				DisplayName: "us-south",
+			},
+			{
+				Name:        foo + "/locations/us-east",
+				DisplayName: "us-east",
+			},
+			{
+				Name:        foo + "/locations/us-west",
+				DisplayName: "us-west",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Errorf("ListLocations: got(-),want(+):\n%s", diff)
+	}
+}
+
+func TestListLocations_missingName(t *testing.T) {
+	s := NewLocationsServer()
+
+	res, err := s.ListLocations(context.Background(), &locpb.ListLocationsRequest{})
+	if err != nil {
+		if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("ListLocations_missingName: got(-),want(+):\n%s", diff)
+		}
+	} else {
+		t.Errorf("ListLocations_missingName: expected an error but got response: %v", res)
+	}
+}
+
+func TestGetLocation(t *testing.T) {
+	s := NewLocationsServer()
+	name := "projects/foo/locations/us-west"
+	want := &locpb.Location{
+		Name:        name,
+		DisplayName: "us-west",
+	}
+
+	got, err := s.GetLocation(context.Background(), &locpb.GetLocationRequest{Name: name})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(got, want, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Errorf("GetLocation: got(-),want(+):\n%s", diff)
+	}
+}
+
+func TestGetLocation_missingName(t *testing.T) {
+	s := NewLocationsServer()
+
+	res, err := s.GetLocation(context.Background(), &locpb.GetLocationRequest{})
+	if err != nil {
+		if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
+			t.Errorf("GetLocation_missingName: got(-),want(+):\n%s", diff)
+		}
+	} else {
+		t.Errorf("GetLocation_missingName: expected an error but got response: %v", res)
+	}
+}

--- a/server/services/locations_service_test.go
+++ b/server/services/locations_service_test.go
@@ -26,9 +26,9 @@ import (
 
 func TestListLocations(t *testing.T) {
 	s := NewLocationsServer()
-	foo := "projects/foo"
+	name := "projects/foo"
 
-	got, err := s.ListLocations(context.Background(), &locpb.ListLocationsRequest{Name: foo})
+	got, err := s.ListLocations(context.Background(), &locpb.ListLocationsRequest{Name: name})
 	if err != nil {
 		t.Error(err)
 	}
@@ -36,19 +36,19 @@ func TestListLocations(t *testing.T) {
 	want := &locpb.ListLocationsResponse{
 		Locations: []*locpb.Location{
 			{
-				Name:        foo + "/locations/us-north",
+				Name:        name + "/locations/us-north",
 				DisplayName: "us-north",
 			},
 			{
-				Name:        foo + "/locations/us-south",
+				Name:        name + "/locations/us-south",
 				DisplayName: "us-south",
 			},
 			{
-				Name:        foo + "/locations/us-east",
+				Name:        name + "/locations/us-east",
 				DisplayName: "us-east",
 			},
 			{
-				Name:        foo + "/locations/us-west",
+				Name:        name + "/locations/us-west",
 				DisplayName: "us-west",
 			},
 		},
@@ -63,12 +63,12 @@ func TestListLocations_missingName(t *testing.T) {
 	s := NewLocationsServer()
 
 	res, err := s.ListLocations(context.Background(), &locpb.ListLocationsRequest{})
-	if err != nil {
-		if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
-			t.Errorf("ListLocations_missingName: got(-),want(+):\n%s", diff)
-		}
-	} else {
+	if err == nil {
 		t.Errorf("ListLocations_missingName: expected an error but got response: %v", res)
+	}
+
+	if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("ListLocations_missingName: got(-),want(+):\n%s", diff)
 	}
 }
 
@@ -94,11 +94,11 @@ func TestGetLocation_missingName(t *testing.T) {
 	s := NewLocationsServer()
 
 	res, err := s.GetLocation(context.Background(), &locpb.GetLocationRequest{})
-	if err != nil {
-		if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
-			t.Errorf("GetLocation_missingName: got(-),want(+):\n%s", diff)
-		}
-	} else {
+	if err == nil {
 		t.Errorf("GetLocation_missingName: expected an error but got response: %v", res)
+	}
+
+	if diff := cmp.Diff(err, missingName, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("GetLocation_missingName: got(-),want(+):\n%s", diff)
 	}
 }

--- a/server/services/services.go
+++ b/server/services/services.go
@@ -20,6 +20,8 @@ import (
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 
+	locpb "google.golang.org/genproto/googleapis/cloud/location"
+	iampb "google.golang.org/genproto/googleapis/iam/v1"
 	lropb "google.golang.org/genproto/googleapis/longrunning"
 )
 
@@ -36,6 +38,8 @@ type Backend struct {
 
 	// Supporting protos
 	OperationsServer lropb.OperationsServer
+	LocationsServer  locpb.LocationsServer
+	IAMPolicyServer  iampb.IAMPolicyServer
 
 	// Other supporting data structures
 	StdLog, ErrLog   *log.Logger

--- a/util/cmd/release/main.go
+++ b/util/cmd/release/main.go
@@ -81,6 +81,10 @@ func main() {
 	complianceSrc := filepath.Join("schema", "google", "showcase", "v1beta1", "compliance_suite.json")
 	util.Execute("cp", complianceSrc, "dist")
 
+	// Copy the API Service config for easy access by generators.
+	serviceYamlSrc := filepath.Join("schema", "google", "showcase", "v1beta1", "showcase_v1beta1.yaml")
+	util.Execute("cp", serviceYamlSrc, "dist")
+
 	// Find gapic-showcase version
 	version, err := exec.Command("go", "run", "./cmd/gapic-showcase", "--version").Output()
 	if err != nil {


### PR DESCRIPTION
Adds Location and IAMPolicy mix-in service gRPC implementations.

Adds an API Service configuration file with mix-in APIs and their `http.rules`.