### PR TITLE
chore: enable windows binary build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,11 +89,8 @@ jobs:
             arch: arm
           - os: darwin
             arch: amd64
-          # Disable windows build because it is not compiling for some reason.
-          # TODO(noahdietz): https://github.com/googleapis/gapic-showcase/issues/603
-          #
-          # - os: windows
-          #   arch: amd64
+          - os: windows
+            arch: amd64
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/cmd/gapic-showcase/run.go
+++ b/cmd/gapic-showcase/run.go
@@ -38,7 +38,7 @@ func init() {
 			cmuxServer := CreateAllEndpoints(config)
 
 			done := make(chan os.Signal, 2)
-			signal.Notify(done, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGSTOP)
+			signal.Notify(done, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGHUP)
 			go func() {
 				sig := <-done
 				stdLog.Printf("Got signal %q", sig)


### PR DESCRIPTION
Stop watching for `SIGSTOP` because windows libraries do not support this signal and the windows binary build fails. 

If we _really_ want to keep it for linux/macos, I can setup two lists in separate files with build tags for windows vs. non-windows but I don't think this is that important tbh. We don't even support `SIGCONT`, which is what follows `SIGSTOP` to "unpause" a process.

FIxes #603 