### PR TITLE
chore: draft v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+### v0.13.0 / 2021-02-24
+- Add Compliance service for REGAPIC testing
+- Add REGAPIC testing support with genrest
+- Add mix-in service implementations
+- Update API Service config with mix-ins and more
+- Add Bazel proto_library targets for schema/
+- Migrated to GitHub Actions
+- Regen client & CLI with small updates
+- Update dependencies
+
 ### v0.12.0 / 2020-08-12
 - Add client-side retry/deadline testing surface
 - Regen client & CLI with small updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
 ### v0.13.0 / 2021-02-24
-- Add Compliance service for REGAPIC testing
-- Add REGAPIC testing support with genrest
+- Auto-generate REST endpoints for Showcase services via `genrest` (partial)
+- Add Compliance service for generators to use to test REST-transcoding their
+  protos and RPCs (partial)
 - Add mix-in service implementations
 - Update API Service config with mix-ins and more
 - Add Bazel proto_library targets for schema/

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ page, or simply by installing from source using go.
 
 ### Docker
 ```sh
-$ docker pull gcr.io/gapic-images/gapic-showcase:0.12.0
+$ docker pull gcr.io/gapic-images/gapic-showcase:0.13.0
 $ docker run \
     --rm \
     -p 7469:7469/tcp \
     -p 7469:7469/udp \
-    gcr.io/gapic-images/gapic-showcase:0.12.0 \
+    gcr.io/gapic-images/gapic-showcase:0.13.0 \
     --help
 > Root command of gapic-showcase
 >
@@ -51,7 +51,7 @@ $ docker run \
 
 ### Binary
 ```sh
-$ export GAPIC_SHOWCASE_VERSION=0.12.0
+$ export GAPIC_SHOWCASE_VERSION=0.13.0
 $ export OS=linux
 $ export ARCH=amd64
 $ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v${GAPIC_SHOWCASE_VERSION}/gapic-showcase-${GAPIC_SHOWCASE_VERSION}-${OS}-${ARCH}.tar.gz | sudo tar -zx --directory /usr/local/bin/

--- a/cmd/gapic-showcase/version.go
+++ b/cmd/gapic-showcase/version.go
@@ -18,7 +18,7 @@ func init() {
 	// Make roots version option only emit the version. This is used in Actions.
 	// The template looks weird on purpose. Leaving as a single line causes the
 	// output to append an extra character.
-	rootCmd.Version = "0.12.0"
+	rootCmd.Version = "0.13.0"
 	rootCmd.SetVersionTemplate(
 		`{{printf "%s" .Version}}`)
 }

--- a/util/cmd/bump_version/main.go
+++ b/util/cmd/bump_version/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const currentAPIVersion = "v1beta1"
-const currentReleaseVersion = "0.12.0"
+const currentReleaseVersion = "0.13.0"
 
 // This script updates the release version or API version of files in gapic-showcase.
 // This script is used on API and release version bumps. This script must be run in


### PR DESCRIPTION
Changes include:
- Add Compliance service for REGAPIC testing
- Add REGAPIC testing support with genrest
- Add mix-in service implementations
- Update API Service config with mix-ins and more
- Add Bazel proto_library targets for schema/
- Migrated to GitHub Actions
- Regen client & CLI with small updates
- Update dependencies