### PR TITLE
chore: fix windows binary upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |
           gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output gapic-showcase ./cmd/gapic-showcase && \
-          tar cvfz gapic-showcase.tar.gz gapic-showcase
+          tar cvfz gapic-showcase.tar.gz gapic-showcase*
       - name: Upload the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} release.
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
Fixes #619 

The windows binary gets the `.exe` suffix causing the `tar` command targeting just `gapic-showcase` to fail, because it is actually `gapic-showcase.exe`.