### PR TITLE
chore: tidy go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,7 @@ google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc/examples v0.0.0-20201022203757-eb7fc22e4562 h1:2Oc4bkImca32UTscRZzHANKzHTzh7N9FnLP3CFPZJbU=
 google.golang.org/grpc/examples v0.0.0-20201022203757-eb7fc22e4562/go.mod h1:IBqQ7wSUJ2Ep09a8rMWFsg4fmI2r38zwsq8a0GgxXpM=


### PR DESCRIPTION
For some reason, the [renovatebot PR](https://github.com/googleapis/gapic-showcase/pull/623/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63) didn't properly tidy the `go.sum` which means some development tools don't work.