### PR TITLE
chore: fix go vet/lint warnings

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,7 @@ google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc/examples v0.0.0-20201022203757-eb7fc22e4562 h1:2Oc4bkImca32UTscRZzHANKzHTzh7N9FnLP3CFPZJbU=
 google.golang.org/grpc/examples v0.0.0-20201022203757-eb7fc22e4562/go.mod h1:IBqQ7wSUJ2Ep09a8rMWFsg4fmI2r38zwsq8a0GgxXpM=

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -407,8 +407,8 @@ func TestPagedExpand(t *testing.T) {
 			&pb.PagedExpandRequest{Content: "Hello world!"},
 			&pb.PagedExpandResponse{
 				Responses: []*pb.EchoResponse{
-					&pb.EchoResponse{Content: "Hello"},
-					&pb.EchoResponse{Content: "world!"},
+					{Content: "Hello"},
+					{Content: "world!"},
 				},
 			},
 		},
@@ -416,8 +416,8 @@ func TestPagedExpand(t *testing.T) {
 			&pb.PagedExpandRequest{PageSize: 3, Content: "Hello world!"},
 			&pb.PagedExpandResponse{
 				Responses: []*pb.EchoResponse{
-					&pb.EchoResponse{Content: "Hello"},
-					&pb.EchoResponse{Content: "world!"},
+					{Content: "Hello"},
+					{Content: "world!"},
 				},
 			},
 		},
@@ -428,9 +428,9 @@ func TestPagedExpand(t *testing.T) {
 			},
 			&pb.PagedExpandResponse{
 				Responses: []*pb.EchoResponse{
-					&pb.EchoResponse{Content: "The"},
-					&pb.EchoResponse{Content: "rain"},
-					&pb.EchoResponse{Content: "in"},
+					{Content: "The"},
+					{Content: "rain"},
+					{Content: "in"},
 				},
 				NextPageToken: "3",
 			},
@@ -443,9 +443,9 @@ func TestPagedExpand(t *testing.T) {
 			},
 			&pb.PagedExpandResponse{
 				Responses: []*pb.EchoResponse{
-					&pb.EchoResponse{Content: "Spain"},
-					&pb.EchoResponse{Content: "falls"},
-					&pb.EchoResponse{Content: "mainly"},
+					{Content: "Spain"},
+					{Content: "falls"},
+					{Content: "mainly"},
 				},
 				NextPageToken: "6",
 			},

--- a/server/services/messaging_service_test.go
+++ b/server/services/messaging_service_test.go
@@ -1518,6 +1518,8 @@ func TestConnect(t *testing.T) {
 				t.Fatal(err)
 			}
 		default:
+			// Empty default so that the select statement doesn't block
+			// and the loop can continue.
 		}
 	}
 

--- a/server/services/operations_service_test.go
+++ b/server/services/operations_service_test.go
@@ -61,11 +61,11 @@ func (m *messagingServerWrapper) FilteredListBlurbs(ctx context.Context, r *pb.L
 
 func TestGetOperation_searchBlurbs(t *testing.T) {
 	expected := []*pb.Blurb{
-		&pb.Blurb{
+		{
 			User:    "users/rumble",
 			Content: &pb.Blurb_Text{Text: "woof"},
 		},
-		&pb.Blurb{
+		{
 			User:    "users/ekko",
 			Content: &pb.Blurb_Text{Text: "bark"},
 		},
@@ -77,21 +77,21 @@ func TestGetOperation_searchBlurbs(t *testing.T) {
 			parentUids:     map[string]*server.UniqID{},
 			token:          server.NewTokenGenerator(),
 			blurbKeys: map[string]blurbIndex{
-				"users/rumble/profile/messages/1": blurbIndex{
+				"users/rumble/profile/messages/1": {
 					row: "users/rumble/profile",
 					col: 1},
-				"users/rumble/profile/messages/2": blurbIndex{
+				"users/rumble/profile/messages/2": {
 					row: "users/rumble/profile",
 					col: 2},
-				"users/rumble/profile/messages/3": blurbIndex{
+				"users/rumble/profile/messages/3": {
 					row: "users/rumble/profile",
 					col: 3},
-				"users/rumble/profile/messages/4": blurbIndex{
+				"users/rumble/profile/messages/4": {
 					row: "users/rumble/profile",
 					col: 4},
 			},
 			blurbs: map[string][]blurbEntry{
-				"users/rumble/profile": []blurbEntry{
+				"users/rumble/profile": {
 					blurbEntry{blurb: expected[0]},
 					blurbEntry{
 						blurb: &pb.Blurb{

--- a/server/services/testing_service.go
+++ b/server/services/testing_service.go
@@ -33,7 +33,7 @@ func NewTestingServer(observerRegistry server.GrpcObserverRegistry) pb.TestingSe
 	name := fmt.Sprintf("sessions/-")
 	defaultSession := server.NewSession(name, pb.Session_V1_LATEST, observerRegistry)
 	defaultSession.RegisterTests(spec.ShowcaseTests(name, pb.Session_V1_LATEST))
-	sessions := []sessionEntry{sessionEntry{session: defaultSession}}
+	sessions := []sessionEntry{{session: defaultSession}}
 	keys := map[string]int{name: len(sessions) - 1}
 
 	s := &testingServerImpl{

--- a/server/services/testing_service_test.go
+++ b/server/services/testing_service_test.go
@@ -135,7 +135,7 @@ func Test_GetSession_deleted(t *testing.T) {
 }
 
 func Test_ListSessions_invalidToken(t *testing.T) {
-	sessions := []sessionEntry{sessionEntry{session: &sessionMock{}}}
+	sessions := []sessionEntry{{session: &sessionMock{}}}
 	keys := map[string]int{"name": len(sessions) - 1}
 
 	s := &testingServerImpl{
@@ -218,7 +218,7 @@ func Test_ReportSession(t *testing.T) {
 	want := &pb.ReportSessionResponse{
 		Result: pb.ReportSessionResponse_PASSED,
 	}
-	sessions := []sessionEntry{sessionEntry{session: &sessionMock{wantReport: want}}}
+	sessions := []sessionEntry{{session: &sessionMock{wantReport: want}}}
 	keys := map[string]int{"name": 0}
 
 	s := &testingServerImpl{
@@ -259,7 +259,7 @@ func Test_ListTests(t *testing.T) {
 	want := &pb.ListTestsResponse{
 		Tests: []*pb.Test{},
 	}
-	sessions := []sessionEntry{sessionEntry{session: &sessionMock{wantList: want}}}
+	sessions := []sessionEntry{{session: &sessionMock{wantList: want}}}
 	keys := map[string]int{"name": 0}
 
 	s := &testingServerImpl{
@@ -299,7 +299,7 @@ func Test_DeleteTest_notFound(t *testing.T) {
 
 func Test_DeleteTests(t *testing.T) {
 	sesh := &sessionMock{}
-	sessions := []sessionEntry{sessionEntry{session: sesh}}
+	sessions := []sessionEntry{{session: sesh}}
 	keys := map[string]int{"name": 0}
 
 	s := &testingServerImpl{


### PR DESCRIPTION
The `lint` job fails [here](https://github.com/googleapis/gapic-showcase/pull/626/checks?check_run_id=2006650208) on `go vet` because of some usage of `testing` APIs from none `testing` goroutines. This fixes that and some other minor linter warnings.

Also, this tidies the `go.sum`, which was going to be done in https://github.com/googleapis/gapic-showcase/pull/626 but that was blocked by these vet warnings. The vet warnings fix failed CI b.c the `go.sum` needed to be fixed. So this submits them together.