### PR TITLE
chore: fix collision with operation helper

### DIFF
--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -96,6 +96,16 @@ func CompileProtos(version string) {
 			"cmd/gapic-showcase/wait.go",
 			"s/EndEnd_time/EndEndTime/g",
 		},
+		// Fixes a name collision with the operation helper WaitOperation by renaming the mixin method.
+		{
+			"client/echo_client.go",
+			"1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}",
+		},
+		// Fixes a name collision with the operation helper WaitOperation by renaming the mixin method.
+		{
+			"client/echo_client_example_test.go",
+			"1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}",
+		},
 	}
 	command = []string{
 		"sed",


### PR DESCRIPTION
There is an RPC named `Echo.Wait` that returns an LRO which creates a helper `WaitOperation` which is the same name as the RPC `Operations.WaitOperation` generated as a mixin method. This is a pretty one-off case as a method named `Wait` returning an LRO is not likely in an actual API. So we just rename the generated mixin method using `sed`  post generation.