### PR TITLE
feat: Ensure full body responses from REST endpoints

### DIFF
--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -26,21 +26,9 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func allowCompactJSON() *resttools.JSONMarshalOptions {
-	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{
-		Multiline:       false,
-		AllowPartial:    false,
-		UseEnumNumbers:  false,
-		EmitUnpopulated: false,
-	})
-	return &resttools.JSONMarshaler
-}
-
 // TestRESTCalls tests that arbitrary rest calls received by the Showcase REST server are handled
 // correctly.
 func TestRESTCalls(t *testing.T) {
-	defer allowCompactJSON().Restore()
-
 	server := httptest.NewUnstartedServer(nil)
 	backend := createBackends()
 	restServer := newEndpointREST(nil, backend)
@@ -53,6 +41,7 @@ func TestRESTCalls(t *testing.T) {
 		verb       string
 		path       string
 		body       string
+		fullJSON   bool
 		want       string
 		statusCode int // 0 taken to mean 200 for simplicity
 	}{
@@ -85,15 +74,58 @@ func TestRESTCalls(t *testing.T) {
 			path:       "/v1beta1/repeat:query?info.f_string=jonas mila",
 			statusCode: 400, // unescaped space in query param
 		},
+
+		{
+			// Test responses:
+			//   1. unset optional field absent
+			//   2. zero-set optional field present
+			//   3. unset non-optional field present
+			//   4. enum field is symbolic rather than numeric
+			verb:     "POST",
+			path:     "/v1beta1/repeat:body",
+			body:     `{"info":{"fString":"jonas^ mila", "p_double": 0}}`,
+			fullJSON: true,
+			want: `{
+                          "info": {
+                            "fString": "jonas^ mila",
+                            "fInt32": 0,
+                            "fSint32": 0,
+                            "fSfixed32": 0,
+                            "fUint32": 0,
+                            "fFixed32": 0,
+                            "fInt64": "0",
+                            "fSint64": "0",
+                            "fSfixed64": "0",
+                            "fUint64": "0",
+                            "fFixed64": "0",
+                            "fDouble": 0,
+                            "fFloat": 0,
+                            "fBool": false,
+                            "fBytes": "",
+                            "fKingdom": "LIFE_KINGDOM_UNSPECIFIED",
+                            "fChild": null,
+                            "pDouble": 0
+                          }
+                        }`,
+		},
 	} {
+
+		var jsonOptions *resttools.JSONMarshalOptions
+		if testCase.fullJSON {
+			jsonOptions = allowFullJSON()
+		} else {
+			jsonOptions = allowCompactJSON()
+		}
 
 		request, err := http.NewRequest(testCase.verb, server.URL+testCase.path, strings.NewReader(testCase.body))
 		if err != nil {
+			jsonOptions.Restore()
 			t.Fatal(err)
 		}
 
 		response, err := http.DefaultClient.Do(request)
 		if err != nil {
+			jsonOptions.Restore()
 			t.Fatal(err)
 		}
 
@@ -106,18 +138,47 @@ func TestRESTCalls(t *testing.T) {
 			t.Errorf("  request: %v", request)
 		} else if want != 200 {
 			// we got the expected error
+			jsonOptions.Restore()
 			continue
 		}
 
 		body, err := ioutil.ReadAll(response.Body)
 		response.Body.Close()
 		if err != nil {
+			jsonOptions.Restore()
 			log.Fatal(err)
 		}
-		if got, want := string(body), testCase.want; got != want {
-			t.Errorf("testcase %2d: body: got `%s`, want %q", idx, got, want)
+		if got, want := string(body), testCase.want; noSpace(got) != noSpace(want) {
+			t.Errorf("testcase %2d: body: got `%s`, want %s", idx, got, want)
 			t.Errorf("  request: %v", request)
 		}
+		jsonOptions.Restore()
 	}
 
+}
+
+// allowFullJSON ensures that resttools JSONMarshaler uses the compact representation until
+// explicitly restored; this makes some tests shorter to configure and easier to understand.
+func allowCompactJSON() *resttools.JSONMarshalOptions {
+	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{
+		Multiline:       false,
+		AllowPartial:    false,
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+	})
+	return &resttools.JSONMarshaler
+}
+
+// allowFullJSON ensures that resttools JSONMarshaler uses the production configuration until
+// explicitly restored.
+func allowFullJSON() *resttools.JSONMarshalOptions {
+	resttools.JSONMarshaler.Replace(nil)
+	return &resttools.JSONMarshaler
+}
+
+// noSpace removes whitespace from src. This is useful for processing formatted responses or
+// expected values without having to worry about whitespace matches.
+func noSpace(src string) string {
+	str := strings.ReplaceAll(src, "\n", "")
+	return strings.ReplaceAll(str, " ", "")
 }

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -157,7 +157,7 @@ func TestRESTCalls(t *testing.T) {
 
 }
 
-// allowFullJSON ensures that resttools JSONMarshaler uses the compact representation until
+// allowCompactJSON ensures that resttools JSONMarshaler uses the compact representation until
 // explicitly restored; this makes some tests shorter to configure and easier to understand.
 func allowCompactJSON() *resttools.JSONMarshalOptions {
 	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -21,11 +21,26 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/googleapis/gapic-showcase/util/genrest/resttools"
+	"google.golang.org/protobuf/encoding/protojson"
 )
+
+func allowCompactJSON() *resttools.JSONMarshalOptions {
+	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{
+		Multiline:       false,
+		AllowPartial:    false,
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+	})
+	return &resttools.JSONMarshaler
+}
 
 // TestRESTCalls tests that arbitrary rest calls received by the Showcase REST server are handled
 // correctly.
 func TestRESTCalls(t *testing.T) {
+	defer allowCompactJSON().Restore()
+
 	server := httptest.NewUnstartedServer(nil)
 	backend := createBackends()
 	restServer := newEndpointREST(nil, backend)

--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -157,8 +157,8 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				source.P("")
 			}
 			source.P("")
-			source.P("  marshaler := &jsonpb.Marshaler{}")
-			source.P("  requestJSON, _ := marshaler.MarshalToString(%s)", handler.RequestVariable)
+			source.P("  marshaler := resttools.ToJSON()")
+			source.P("  requestJSON, _ := marshaler.Marshal(%s)", handler.RequestVariable)
 			source.P(`  backend.StdLog.Printf("  request: %%s", requestJSON)`)
 			source.P("")
 			// TODO: In the future, we may want to redirect all REST-endpoint requests to the gRPC endpoint so that the gRPC-registered observers get invoked.
@@ -169,13 +169,13 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 			source.P("    return")
 			source.P("  }")
 			source.P("")
-			source.P("  json, err := marshaler.MarshalToString(%s)", handler.ResponseVariable)
+			source.P("  json, err := marshaler.Marshal(%s)", handler.ResponseVariable)
 			source.P("  if err != nil {")
 			source.P(`    backend.Error(w, http.StatusInternalServerError, "error json-encoding response: %%s", err.Error())`)
 			source.P("    return")
 			source.P("  }")
 			source.P("")
-			source.P("  w.Write([]byte(json))")
+			source.P("  w.Write(json)")
 			source.P("}\n")
 		}
 

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -29,11 +29,18 @@ func ToJSON() *protojson.MarshalOptions {
 	return &copy
 }
 
+// FromJSON returns a copy of the current global JSON unmarshaling options. Modifications to this copy
+// do not change the values of these options returned in subsequent calls to this function. This is
+// the function Showcase REST endpoints should use to handle JSON unmarshaling.
+func FromJSON() *protojson.UnmarshalOptions {
+	return &protojson.UnmarshalOptions{}
+}
+
 // JSONMarshaler captures the JSON marshaling options. It is intended only for test of Showcase
 // functionality (not for normal Showcase use or tests of generators against Showcase).
 var JSONMarshaler JSONMarshalOptions
 
-// JSONMarshalOptions contains the current JSOJN marshaling options used by REST endpoints, and
+// JSONMarshalOptions contains the current JSON marshaling options used by REST endpoints, and
 // allows for temporarily replacing these global options and then restoring them. This functionality
 // is useful for some tests.
 type JSONMarshalOptions struct {
@@ -43,7 +50,7 @@ type JSONMarshalOptions struct {
 
 // Replace replaces the current JSON marshaling options with those provided by opt. Call Restore()
 // to restore the production options. Only one replacement can be active at a time; subsequent calls
-// for hang waiting for the first call's mutex to release.
+// for hang waiting for the first call's mutex to be released.
 //
 // As a special case, if opt==nil, the replacement is with the production options themselves; this
 // is useful for test that need to lock the production options while they are running against other

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -36,7 +36,7 @@ func FromJSON() *protojson.UnmarshalOptions {
 	return &protojson.UnmarshalOptions{}
 }
 
-// JSONMarshaler captures the JSON marshaling options. It is intended only for test of Showcase
+// JSONMarshaler captures the JSON marshaling options. It is intended only for tests of Showcase
 // functionality (not for normal Showcase use or tests of generators against Showcase).
 var JSONMarshaler JSONMarshalOptions
 
@@ -50,11 +50,11 @@ type JSONMarshalOptions struct {
 
 // Replace replaces the current JSON marshaling options with those provided by opt. Call Restore()
 // to restore the production options. Only one replacement can be active at a time; subsequent calls
-// for hang waiting for the first call's mutex to be released.
+// hang waiting for the first call's mutex to be released.
 //
 // As a special case, if opt==nil, the replacement is with the production options themselves; this
-// is useful for test that need to lock the production options while they are running against other
-// tests which may need to change them.
+// is useful for tests that need to lock the production options to protect from other tests which
+// may need to change them.
 func (jm *JSONMarshalOptions) Replace(opt *protojson.MarshalOptions) {
 	jm.mu.Lock()
 	if opt == nil {

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resttools
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ToJSON returns a copy of the current global JSON marshaling options in
+// JSONMarshaler. Modifications to this copy do not change the values of these options returned in
+// subsequent calls to this function. This is the function Showcase REST endpoints should use to
+// handle JSON marshaling.
+func ToJSON() *protojson.MarshalOptions {
+	copy := *JSONMarshaler.current
+	return &copy
+}
+
+// JSONMarshaler captures the JSON marshaling options. It is intended only for test of Showcase
+// functionality (not for normal Showcase use or tests of generators against Showcase).
+var JSONMarshaler JSONMarshalOptions
+
+// JSONMarshalOptions contains the current JSOJN marshaling options used by REST endpoints, and
+// allows for temporarily replacing these global options and then restoring them. This functionality
+// is useful for some tests.
+type JSONMarshalOptions struct {
+	current, saved *protojson.MarshalOptions
+	mu             sync.Mutex
+}
+
+// Replace replaces the current JSON marshaling options with those provided by opt. Call Restore()
+// to restore the production options. Only one replacement can be active at a time; subsequent calls
+// for hang waiting for the first call's mutex to release.
+//
+// As a special case, if opt==nil, the replacement is with the production options themselves; this
+// is useful for test that need to lock the production options while they are running against other
+// tests which may need to change them.
+func (jm *JSONMarshalOptions) Replace(opt *protojson.MarshalOptions) {
+	jm.mu.Lock()
+	if opt == nil {
+		opt = jm.current
+	}
+	jm.saved = jm.current
+	jm.current = opt
+}
+
+// Restore restores the production JSON marshaling options. There must be an active Replace() called
+// previously.
+func (jm *JSONMarshalOptions) Restore() {
+	jm.current = jm.saved
+	jm.saved = nil
+	jm.mu.Unlock()
+}
+
+func init() {
+	JSONMarshaler.current = &protojson.MarshalOptions{
+		Multiline:       true,
+		AllowPartial:    false,
+		UseEnumNumbers:  false,
+		EmitUnpopulated: true,
+	}
+
+}


### PR DESCRIPTION
Also, replace deprecated `jsonpb` with `protojson` in genrest (`jsonpb` persists elsewhere in Showcase for now).