### PR TITLE
Enforce lower-camel-cased field names in REST bodies and query params

### DIFF
--- a/cmd/gapic-showcase/compliance_suite_errors_test.go
+++ b/cmd/gapic-showcase/compliance_suite_errors_test.go
@@ -40,8 +40,15 @@ func TestComplianceSuiteErrors(t *testing.T) {
 	defer server.Close()
 
 	restRPCs := map[string][]prepRepeatDataTestFunc{
-		"Compliance.RepeatDataBodyInfo":   {prepRepeatDataBodyInfoNegativeTestRepeatedFields, prepRepeatDataBodyInfoSnakeCasedFieldNames},
-		"Compliance.RepeatDataQuery":      {prepRepeatDataQueryNegativeTestNumericEnums, prepRepeatDataQueryNegativeTestNumericOptionalEnums},
+		"Compliance.RepeatDataBodyInfo": {
+			prepRepeatDataBodyInfoNegativeTestRepeatedFields,
+			prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames,
+		},
+		"Compliance.RepeatDataQuery": {
+			prepRepeatDataQueryNegativeTestNumericEnums,
+			prepRepeatDataQueryNegativeTestNumericOptionalEnums,
+			prepRepeatDataQueryNegativeTestSnakeCasedFieldNames,
+		},
 		"Compliance.RepeatDataSimplePath": {prepRepeatDataSimplePathNegativeTestEnum},
 	}
 
@@ -102,7 +109,7 @@ func prepRepeatDataBodyInfoNegativeTestRepeatedFields(request *genproto.RepeatRe
 	return name, "POST", "/v1beta1/repeat:bodyinfo" + queryString, string(bodyBytes), err
 }
 
-func prepRepeatDataBodyInfoSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
 	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{
 		Multiline:       true,
 		AllowPartial:    false,
@@ -118,6 +125,13 @@ func prepRepeatDataBodyInfoSnakeCasedFieldNames(request *genproto.RepeatRequest)
 	return name, "POST", "/v1beta1/repeat:bodyinfo", string(bodyBytes), err
 }
 
+func prepRepeatDataQueryNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+	name = "Compliance.RepeatDataQuery#NegativeTestSnakeCasedFieldNames"
+	queryParams := prepRepeatDataTestsQueryParams(request, nil, queryStringSnakeCaser)
+	queryString := prepQueryString(queryParams)
+	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
+}
+
 func prepRepeatDataQueryNegativeTestNumericEnums(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
 	name = "Compliance.RepeatDataQuery#NegativeTestNumericEnums"
 	info := request.GetInfo()
@@ -127,7 +141,7 @@ func prepRepeatDataQueryNegativeTestNumericEnums(request *genproto.RepeatRequest
 	// modifies the request, but since these tests only check that calls fail, we never need to
 	// refer back to the request proto after constructing the REST query.
 	info.FKingdom = pb.ComplianceData_LIFE_KINGDOM_UNSPECIFIED
-	queryParams := append(prepRepeatDataTestsQueryParams(request, nil), badQueryParam)
+	queryParams := append(prepRepeatDataTestsQueryParams(request, nil, queryStringLowerCamelCaser), badQueryParam)
 
 	queryString := prepQueryString(queryParams)
 	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
@@ -142,7 +156,7 @@ func prepRepeatDataQueryNegativeTestNumericOptionalEnums(request *genproto.Repea
 	// modifies the request, but since these tests only check that calls fail, we never need to
 	// refer back to the request proto after constructing the REST query.
 	info.PKingdom = nil
-	queryParams := append(prepRepeatDataTestsQueryParams(request, nil), badQueryParam)
+	queryParams := append(prepRepeatDataTestsQueryParams(request, nil, queryStringLowerCamelCaser), badQueryParam)
 
 	queryString := prepQueryString(queryParams)
 	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err

--- a/cmd/gapic-showcase/compliance_suite_errors_test.go
+++ b/cmd/gapic-showcase/compliance_suite_errors_test.go
@@ -127,7 +127,7 @@ func prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames(request *genproto.Re
 
 func prepRepeatDataQueryNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
 	name = "Compliance.RepeatDataQuery#NegativeTestSnakeCasedFieldNames"
-	queryParams := prepRepeatDataTestsQueryParams(request, nil, queryStringSnakeCaser)
+	queryParams := prepRepeatDataTestsQueryParams(request, nil, queryStringSnakeCaser) // this should cause an error
 	queryString := prepQueryString(queryParams)
 	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
 }

--- a/cmd/gapic-showcase/compliance_suite_test.go
+++ b/cmd/gapic-showcase/compliance_suite_test.go
@@ -325,6 +325,8 @@ func prepQueryString(queryParams []string) string {
 	return queryString
 }
 
+// queryStringCaser is a convenience function type taking a string and returning its representation
+// under a particular casing scheme.
 type queryStringCaser func(string) string
 
 var queryStringLowerCamelCaser, queryStringSnakeCaser queryStringCaser

--- a/cmd/gapic-showcase/compliance_suite_test.go
+++ b/cmd/gapic-showcase/compliance_suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gapic-showcase/server/genproto"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
+	"github.com/googleapis/gapic-showcase/util/genrest/resttools"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -43,6 +44,9 @@ func TestComplianceSuite(t *testing.T) {
 	}
 	server.Start()
 	defer server.Close()
+
+	resttools.JSONMarshaler.Replace(nil)
+	defer resttools.JSONMarshaler.Restore()
 
 	// Set handlers for each test case. When GAPIC generator tests do this, they should have
 	// each of their handlers invoking the correct GAPIC library method for the Showcase API.
@@ -152,13 +156,13 @@ type prepRepeatDataTestFunc func(request *genproto.RepeatRequest) (verb string, 
 
 func prepRepeatDataBodyTest(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
 	name = "Compliance.RepeatDataBody"
-	bodyBytes, err := protojson.Marshal(request)
+	bodyBytes, err := resttools.ToJSON().Marshal(request)
 	return name, "POST", "/v1beta1/repeat:body", string(bodyBytes), err
 }
 
 func prepRepeatDataBodyInfoTest(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
 	name = "Compliance.RepeatDataBodyInfo"
-	bodyBytes, err := protojson.Marshal(request.Info)
+	bodyBytes, err := resttools.ToJSON().Marshal(request.Info)
 	queryString := prepRepeatDataTestsQueryString(request, map[string]bool{"info": true})
 	_ = bodyBytes
 	return name, "POST", "/v1beta1/repeat:bodyinfo" + queryString, string(bodyBytes), err

--- a/cmd/gapic-showcase/compliance_suite_test.go
+++ b/cmd/gapic-showcase/compliance_suite_test.go
@@ -277,7 +277,7 @@ func prepRepeatDataTestsQueryParams(request *genproto.RepeatRequest, exclude map
 		if exclude["info"] || exclude["info."+key] || !condition {
 			return
 		}
-		queryParams = append(queryParams, fmt.Sprintf("info.%s=%s", key, value))
+		queryParams = append(queryParams, fmt.Sprintf("info.%s=%s", resttools.ToDottedLowerCamel(key), value))
 	}
 
 	addParam("f_string", len(info.GetFString()) > 0, url.QueryEscape(info.GetFString()))

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -83,7 +83,7 @@ func TestRESTCalls(t *testing.T) {
 			//   4. enum field is symbolic rather than numeric
 			verb:     "POST",
 			path:     "/v1beta1/repeat:body",
-			body:     `{"info":{"fString":"jonas^ mila", "p_double": 0}}`,
+			body:     `{"info":{"fString":"jonas^ mila", "pDouble": 0}}`,
 			fullJSON: true,
 			want: `{
                           "info": {
@@ -165,6 +165,7 @@ func allowCompactJSON() *resttools.JSONMarshalOptions {
 		AllowPartial:    false,
 		UseEnumNumbers:  false,
 		EmitUnpopulated: false,
+		UseProtoNames:   false, // we want lower-camel-cased field names
 	})
 	return &resttools.JSONMarshaler
 }

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -58,12 +58,12 @@ func TestRESTCalls(t *testing.T) {
 		},
 		{
 			verb: "GET",
-			path: "/v1beta1/repeat:query?info.f_string=jonas+mila",
+			path: "/v1beta1/repeat:query?info.fString=jonas+mila",
 			want: `{"info":{"fString":"jonas mila"}}`,
 		},
 		{
 			verb: "GET",
-			path: "/v1beta1/repeat:query?info.f_string=jonas^mila",
+			path: "/v1beta1/repeat:query?info.fString=jonas^mila",
 
 			// TODO: Fix so that this returns an error, because `^` is not URL-escaped
 			statusCode: 200,
@@ -71,8 +71,23 @@ func TestRESTCalls(t *testing.T) {
 		},
 		{
 			verb:       "GET",
-			path:       "/v1beta1/repeat:query?info.f_string=jonas mila",
+			path:       "/v1beta1/repeat:query?info.fString=jonas mila",
 			statusCode: 400, // unescaped space in query param
+		},
+		{
+			verb:       "GET",
+			path:       "/v1beta1/repeat:query?info.pKingdom=1",
+			statusCode: 400, // numeric value for enum
+		},
+		{
+			verb:       "GET",
+			path:       "/v1beta1/repeat:query?info.p_kingdom=ANIMALIA",
+			statusCode: 400, // non-camel-cased field name
+		},
+		{
+			verb:       "GET",
+			path:       "/v1beta1/repeat:query?info.PKingdom=ANIMALIA",
+			statusCode: 400, // non-lower-camel-cased field name
 		},
 
 		{

--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -125,6 +125,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				source.P("  }")
 
 			case gomodel.BodyFieldSingle:
+				fileImports["bytes"] = ""
 				fileImports["io"] = ""
 
 				// TODO: Ensure this works when the specified field is a scalar. We
@@ -132,14 +133,21 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				// case.
 				source.P("  // Intentional: Field values in the URL path override those set in the body.")
 				source.P("  var %s %s.%s", handler.RequestBodyFieldVariable, handler.RequestBodyFieldPackage, handler.RequestBodyFieldType)
+				source.P("  var jsonReader bytes.Buffer")
+				source.P("  bodyReader := io.TeeReader(r.Body, &jsonReader)")
 				source.P("  rBytes := make([]byte, r.ContentLength)")
-				source.P("  if _, err := r.Body.Read(rBytes); err != nil && err != io.EOF {")
+				source.P("  if _, err := bodyReader.Read(rBytes); err != nil && err != io.EOF {")
 				source.P(`    backend.Error(w, http.StatusBadRequest, "error reading body content: %%s", err)`)
 				source.P("    return")
 				source.P("  }")
 				source.P("")
 				source.P("  if err := resttools.FromJSON().Unmarshal(rBytes, &%s); err != nil {", handler.RequestBodyFieldVariable)
 				source.P(`    backend.Error(w, http.StatusBadRequest, "error reading body into request field '%s': %%s", err)`, handler.RequestBodyFieldProtoName)
+				source.P("    return")
+				source.P("  }")
+				source.P("")
+				source.P("  if err := resttools.CheckRESTBody(&jsonReader, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
+				source.P(`    backend.Error(w, http.StatusBadRequest, "REST body '*' failed format check: %%s", err)`)
 				source.P("    return")
 				source.P("  }")
 				source.P("  %s.%s = &%s", handler.RequestVariable, handler.RequestBodyFieldName, handler.RequestBodyFieldVariable)

--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -306,7 +306,7 @@ func extractPath(template gomodel.PathTemplate, insideVariable bool) (string, []
 			}
 
 			// Here we convert the proto-cased (snake-cased) field path to be JSON-cased
-			// (lower-camel-cased) so that we can keep the resttools.Populate*Field*)_
+			// (lower-camel-cased) so that we can keep the resttools.Populate*Field*()
 			// functions simple, only dealing with JSON-cased field names,
 			part = fmt.Sprintf("{%s:%s}", resttools.ToDottedLowerCamel(seg.Value), subParts)
 			allVariables = append(allVariables, seg.Value)

--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -304,7 +304,11 @@ func extractPath(template gomodel.PathTemplate, insideVariable bool) (string, []
 				return "", nil, err
 
 			}
-			part = fmt.Sprintf("{%s:%s}", seg.Value, subParts)
+
+			// Here we convert the proto-cased (snake-cased) field path to be JSON-cased
+			// (lower-camel-cased) so that we can keep the resttools.Populate*Field*)_
+			// functions simple, only dealing with JSON-cased field names,
+			part = fmt.Sprintf("{%s:%s}", resttools.ToDottedLowerCamel(seg.Value), subParts)
 			allVariables = append(allVariables, seg.Value)
 		}
 		parts[idx] = part

--- a/util/genrest/resttools/checkrestbody.go
+++ b/util/genrest/resttools/checkrestbody.go
@@ -21,9 +21,14 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
+	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
+
+type jsonPayload map[string]interface{}
 
 // CheckRESTBody verifies that any enum fields in message are properly represented in the JSON
 // payload carried by jsonReader: the fields must be either absent or have string values.
@@ -32,19 +37,40 @@ func CheckRESTBody(jsonReader io.Reader, message protoreflect.Message) error {
 	if err != nil {
 		return err
 	}
+
+	var payload jsonPayload
+	json.Unmarshal(jsonBytes, &payload)
+
+	if err := CheckFieldNames(payload); err != nil {
+		return err
+	}
+
 	enumFields := GetEnumFields(message)
-	return CheckJSONEnumFields(jsonBytes, enumFields)
+	return CheckJSONEnumFields(payload, enumFields)
+}
+
+// CheckFieldNames checks that the field names in the JSON request body are properly formatted
+// (lower-camel-cased).
+func CheckFieldNames(payload jsonPayload) error {
+	for fieldName, value := range payload {
+		rune, _ := utf8.DecodeRuneInString(fieldName)
+		if strings.ContainsAny(fieldName, "_- ") || !unicode.IsLower(rune) {
+			return fmt.Errorf("%s field name is not lower-camel-cased; probably want be %q", fieldName, strcase.ToLowerCamel(fieldName))
+		}
+		if nested, ok := value.(map[string]interface{}); ok {
+			if err := CheckFieldNames(nested); err != nil {
+				return fmt.Errorf("%s.%s", fieldName, err)
+			}
+		}
+	}
+	return nil
 }
 
 // CheckJSONEnumFields verifies that each of the fields listed in fieldsToCheck, presumably all
-// referring to enum fields, are encoded correctly in jsonBytes, meaning that the field is absent or
-// its value is a string. Each element of fieldsToCheck is a qualified proto field name represented
-// as a sequence of simple protoreflect.Name.
-func CheckJSONEnumFields(jsonBytes []byte, fieldsToCheck [][]protoreflect.Name) error {
-	// Ref: https://michaelheap.com/golang-encodedecode-arbitrary-json/
-
-	var payload map[string]interface{}
-	json.Unmarshal(jsonBytes, &payload)
+// referring to enum fields, are encoded correctly in the parsed JSON payload, meaning that the
+// field is absent or its value is a string. Each element of fieldsToCheck is a qualified proto
+// field name represented as a sequence of simple protoreflect.Name.
+func CheckJSONEnumFields(payload jsonPayload, fieldsToCheck [][]protoreflect.Name) error {
 	badFields := []string{}
 	for _, fieldPath := range fieldsToCheck {
 		if field, ok := CheckEnum(payload, fieldPath); !ok {
@@ -63,19 +89,19 @@ func CheckJSONEnumFields(jsonBytes []byte, fieldsToCheck [][]protoreflect.Name) 
 // boolean that is true only if either fieldPath is not present or if its value is a string. This
 // means that if fieldPath is a path to an enum field, the boolean will be false if the enum is
 // encoded in the payload using a non-string representation.
-func CheckEnum(payload map[string]interface{}, fieldPath []protoreflect.Name) (fieldName string, ok bool) {
+func CheckEnum(payload jsonPayload, fieldPath []protoreflect.Name) (fieldName string, ok bool) {
 	nameParts := []string{}
 	last := len(fieldPath) - 1
 	var value string
 	var found, isString bool
 	for idx, pathSegment := range fieldPath {
-		segment := string(pathSegment)
+		segment := strcase.ToLowerCamel(string(pathSegment))
 		nameParts = append(nameParts, segment)
 
 		// TODO: For repeated fields, will need to recurse. Consider denoting repeated fields by appending a "*" to the pathSegment
 
 		if idx < last {
-			payload, found = payload[segment].(map[string]interface{})
+			payload, found = payload[segment].(jsonPayload)
 			if !found {
 				// Some elements of the field path are not populated
 				break

--- a/util/genrest/resttools/checkrestbody.go
+++ b/util/genrest/resttools/checkrestbody.go
@@ -28,10 +28,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-type jsonPayload map[string]interface{}
-
 // CheckRESTBody verifies that any enum fields in message are properly represented in the JSON
-// payload carried by jsonReader: the fields must be either absent or have string values.
+// payload carried by jsonReader: the fields must be either absent or have lower-camel-cased names.
 func CheckRESTBody(jsonReader io.Reader, message protoreflect.Message) error {
 	jsonBytes, err := ioutil.ReadAll(jsonReader)
 	if err != nil {
@@ -180,6 +178,9 @@ func computeEnumFields(message protoreflect.MessageDescriptor, currentPath []pro
 	}
 	return results
 }
+
+// jsonPayload is used for unmarshaling arbitrary JSON.
+type jsonPayload map[string]interface{}
 
 // protoEnumFields is a list of fields paths (themselves represented as a list of nested field
 // names) which represent enum fields. This is used to memoize calls to GetEnumFields.

--- a/util/genrest/resttools/checkrestbody_test.go
+++ b/util/genrest/resttools/checkrestbody_test.go
@@ -48,51 +48,51 @@ func TestCheckRESTBody(t *testing.T) {
 	}{
 		{
 			label: "normal case",
-			json:  `{"f_string": "hi", "f_kingdom": "FUNGI"}`,
+			json:  `{"fString": "hi", "fKingdom": "FUNGI"}`,
 		},
 		{
 			label: "normal case, optional field",
-			json:  `{"f_string": "hi", "p_kingdom": "FUNGI"}`,
+			json:  `{"fString": "hi", "pKingdom": "FUNGI"}`,
 		},
 		{
 			label: "normal case, nested message, optional field",
-			json:  `{"f_string": "hi", "f_child": {"p_continent": "AFRICA"}}`,
+			json:  `{"fString": "hi", "fChild": {"pContinent": "AFRICA"}}`,
 		},
 		{
 			label: "normal case, nested optional message",
-			json:  `{"f_string": "hi", "p_child": {"f_continent": "AFRICA"}}`,
+			json:  `{"fString": "hi", "pChild": {"fContinent": "AFRICA"}}`,
 		},
 		{
 			label: "normal case, no enum",
-			json:  `{"f_string": "hi"}`,
+			json:  `{"fString": "hi"}`,
 		},
 		{
 			label: "random string does not fail",
-			json:  `{"f_string": "hi", "f_kingdom": "MONACO"}`,
+			json:  `{"fString": "hi", "fKingdom": "MONACO"}`,
 		},
 		{
 			label:     "numeric enum",
-			json:      `{"f_string": "hi", "f_kingdom": 56}`,
+			json:      `{"fString": "hi", "fKingdom": 56}`,
 			wantError: true,
 		},
 		{
 			label:     "numeric optional enum",
-			json:      `{"f_string": "hi", "p_kingdom": 57}`,
+			json:      `{"fString": "hi", "pKingdom": 57}`,
 			wantError: true,
 		},
 		{
 			label:     "stringy numeric enum",
-			json:      `{"f_string": "hi", "f_kingdom": "56"}`,
+			json:      `{"fString": "hi", "fKingdom": "56"}`,
 			wantError: true,
 		},
 		{
 			label:     "stringy optional numeric enum",
-			json:      `{"f_string": "hi", "f_kingdom": "57"}`,
+			json:      `{"fString": "hi", "fKingdom": "57"}`,
 			wantError: true,
 		},
 		{
 			label:     "stringy number+letter enum",
-			json:      `{"f_string": "hi", "f_kingdom": "56Abacus"}`,
+			json:      `{"fString": "hi", "fKingdom": "56Abacus"}`,
 			wantError: false,
 		},
 	} {

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -15,8 +15,10 @@
 package resttools
 
 import (
+	"strings"
 	"sync"
 
+	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -70,6 +72,15 @@ func (jm *JSONMarshalOptions) Restore() {
 	jm.current = jm.saved
 	jm.saved = nil
 	jm.mu.Unlock()
+}
+
+// ToDottedLowerCamel converts each segment of a dot-delimited field path to be individually lower-camel cased; the dots are preserved.
+func ToDottedLowerCamel(fieldPath string) string {
+	parts := strings.Split(fieldPath, ".")
+	for idx, segment := range parts {
+		parts[idx] = strcase.ToLowerCamel(segment)
+	}
+	return strings.Join(parts, ".")
 }
 
 func init() {

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -74,7 +74,7 @@ func (jm *JSONMarshalOptions) Restore() {
 	jm.mu.Unlock()
 }
 
-// ToDottedLowerCamel converts each segment of a dot-delimited field path to be individually lower-camel cased; the dots are preserved.
+// ToDottedLowerCamel converts each segment of a dot-delimited fieldPath to be individually lower-camel-cased; the dots are preserved.
 func ToDottedLowerCamel(fieldPath string) string {
 	parts := strings.Split(fieldPath, ".")
 	for idx, segment := range parts {

--- a/util/genrest/resttools/json.go
+++ b/util/genrest/resttools/json.go
@@ -78,6 +78,7 @@ func init() {
 		AllowPartial:    false,
 		UseEnumNumbers:  false,
 		EmitUnpopulated: true,
+		UseProtoNames:   false, // we want lower-camel-cased field names
 	}
 
 }

--- a/util/genrest/resttools/populatefield.go
+++ b/util/genrest/resttools/populatefield.go
@@ -25,7 +25,7 @@ import (
 
 // PopulateSingularFields sets the fields within protoMessage to the values provided in
 // fieldValues. The fields and values are provided as a map of field paths to the string
-// representation of their values. The fields paths can refer to fields nested arbitrarily deep
+// representation of their values. The field paths can refer to fields nested arbitrarily deep
 // within protoMessage; each path element must be lower-camel-cased. This returns an error if any
 // field path is not valid or if any value can't be parsed into the correct data type for the field.
 func PopulateSingularFields(protoMessage proto.Message, fieldValues map[string]string) error {
@@ -187,6 +187,11 @@ func parseBool(asString string) (bool, error) {
 	}
 }
 
+// findFieldByProtoName queries `fields` for the unique field whose lower-camel-cased name is given
+// by `fieldName` and returns the corresponding FieldDescriptor or nil if none can be found. This
+// returns an error if more than one entry in `fields` has the same lower-camel-cased field
+// representations (as would occur, for example, for fields with proto names `foo5_bar` and
+// `foo_5_bar`).
 func findProtoFieldByJSONName(fieldName string, fields protoreflect.FieldDescriptors) (result protoreflect.FieldDescriptor, err error) {
 	if ToDottedLowerCamel(fieldName) != fieldName {
 		return nil, fmt.Errorf("field name %q is not lower-camel-cased", fieldName)

--- a/util/genrest/resttools/populatefield_test.go
+++ b/util/genrest/resttools/populatefield_test.go
@@ -29,61 +29,78 @@ func TestPopulateOneFieldError(t *testing.T) {
 	}{
 		// field path errors
 
-		{".f_string", "hi"},
-		{"f_child..f_string", "hi"},
-		{"f_child.", "hi"},
-		{"f_child.x", "hi"},
-		{"f_child.x.f_string", "hi"},
-		{"f_child.f_string.f_child", "hi"},
-		{"f_child.f_child", "hi"},
+		{".fString", "hi"},
+		{"fChild..fString", "hi"},
+		{"fChild.", "hi"},
+		{"fChild.x", "hi"},
+		{"fChild.x.fString", "hi"},
+		{"fChild.fString.fChild", "hi"},
+		{"fChild.fChild", "hi"},
 
 		// parsing errors
 
-		{"f_int32", "hello"},
-		{"f_sint32", "hello"},
-		{"f_sfixed32", "hello"},
-		{"f_int32", "2147483648"},    // max int32 + 1
-		{"f_sint32", "2147483648"},   // max int32 + 1
-		{"f_sfixed32", "2147483648"}, // max int32 + 1
-		{"f_int32", "1.1"},
-		{"f_sint32", "1.1"},
-		{"f_sfixed32", "1.1"},
+		{"fInt32", "hello"},
+		{"fSint32", "hello"},
+		{"fSfixed32", "hello"},
+		{"fInt32", "2147483648"},    // max int32 + 1
+		{"fSint32", "2147483648"},   // max int32 + 1
+		{"fSfixed32", "2147483648"}, // max int32 + 1
+		{"fInt32", "1.1"},
+		{"fSint32", "1.1"},
+		{"fSfixed32", "1.1"},
 
-		{"f_uint32", "hello"},
-		{"f_fixed32", "hello"},
-		{"f_uint32", "4294967296"},  // max uint32 + 1
-		{"f_fixed32", "4294967296"}, // max uint32 + 1
-		{"f_uint32", "1.1"},
-		{"f_fixed32", "1.1"},
-		{"f_uint32", "-1"},
-		{"f_fixed32", "-1"},
+		{"fUint32", "hello"},
+		{"fFixed32", "hello"},
+		{"fUint32", "4294967296"},  // max uint32 + 1
+		{"fFixed32", "4294967296"}, // max uint32 + 1
+		{"fUint32", "1.1"},
+		{"fFixed32", "1.1"},
+		{"fUint32", "-1"},
+		{"fFixed32", "-1"},
 
-		{"f_int64", "hello"},
-		{"f_sint64", "hello"},
-		{"f_sfixed64", "hello"},
-		{"f_int64", "9223372036854775808"},    // max int64 + 1
-		{"f_sint64", "9223372036854775808"},   // max int64 + 1
-		{"f_sfixed64", "9223372036854775808"}, // max int64 + 1
-		{"f_int64", "1.1"},
-		{"f_sint64", "1.1"},
-		{"f_sfixed64", "1.1"},
+		{"fInt64", "hello"},
+		{"fSint64", "hello"},
+		{"fSfixed64", "hello"},
+		{"fInt64", "9223372036854775808"},    // max int64 + 1
+		{"fSint64", "9223372036854775808"},   // max int64 + 1
+		{"fSfixed64", "9223372036854775808"}, // max int64 + 1
+		{"fInt64", "1.1"},
+		{"fSint64", "1.1"},
+		{"fSfixed64", "1.1"},
 
-		{"f_uint64", "hello"},
-		{"f_fixed64", "hello"},
-		{"f_uint64", "18446744073709551616"},  // max uint64 + 1
-		{"f_fixed64", "18446744073709551616"}, // max uint64 + 1
-		{"f_uint64", "1.1"},
-		{"f_fixed64", "1.1"},
-		{"f_uint64", "-1"},
-		{"f_fixed64", "-1"},
+		{"fUint64", "hello"},
+		{"fFixed64", "hello"},
+		{"fUint64", "18446744073709551616"},  // max uint64 + 1
+		{"fFixed64", "18446744073709551616"}, // max uint64 + 1
+		{"fUint64", "1.1"},
+		{"fFixed64", "1.1"},
+		{"fUint64", "-1"},
+		{"fFixed64", "-1"},
 
-		{"f_float", "hello"},
-		{"f_double", "hello"},
-		{"f_float", "1e+39"},   // exponent too large
-		{"f_double", "1e+309"}, // exponent too large
+		{"fFloat", "hello"},
+		{"fDouble", "hello"},
+		{"fFloat", "1e+39"},   // exponent too large
+		{"fDouble", "1e+309"}, // exponent too large
 
-		{"f_bool", "hello"},
-		{"f_bool", "13"},
+		{"fBool", "hello"},
+		{"fBool", "13"},
+
+		// wrong casing
+		{"f_string", "alphabet"},
+		{"f_int32", "1"},
+		{"f_sint32", "2"},
+		{"f_sfixed32", "3"},
+		{"f_uint32", "4"},
+		{"f_fixed32", "5"},
+		{"f_int64", "6"},
+		{"f_sint64", "7"},
+		{"f_sfixed64", "8"},
+		{"f_uint64", "9"},
+		{"f_fixed64", "10"},
+		{"f_float", "11"},
+		{"f_double", "12"},
+		{"f_bool", "true"},
+		{"f_bytes", "greetings"},
 	} {
 		complianceData := &genprotopb.ComplianceData{}
 		err := PopulateOneField(complianceData, testCase.field, []string{testCase.value})
@@ -104,128 +121,128 @@ func TestPopulateSingularFields(t *testing.T) {
 		{
 			label: "scalar datatypes",
 			fields: map[string]string{
-				"f_string": "alphabet",
+				"fString": "alphabet",
 
-				"f_int32":    "2147483647", // max int32
-				"f_sint32":   "2147483647", // max int32
-				"f_sfixed32": "2147483647", // max int32
+				"fInt32":    "2147483647", // max int32
+				"fSint32":   "2147483647", // max int32
+				"fSfixed32": "2147483647", // max int32
 
-				"f_uint32":  "4294967295", // max uint32
-				"f_fixed32": "4294967295", // max uint32
+				"fUint32":  "4294967295", // max uint32
+				"fFixed32": "4294967295", // max uint32
 
-				"f_int64":    "9223372036854775807", // max int64
-				"f_sint64":   "9223372036854775807", // max int64
-				"f_sfixed64": "9223372036854775807", // max int64
+				"fInt64":    "9223372036854775807", // max int64
+				"fSint64":   "9223372036854775807", // max int64
+				"fSfixed64": "9223372036854775807", // max int64
 
-				"f_uint64":  "18446744073709551615", // max uint64
-				"f_fixed64": "18446744073709551615", // max uint64
+				"fUint64":  "18446744073709551615", // max uint64
+				"fFixed64": "18446744073709551615", // max uint64
 
-				"f_float":  "3.40282346638528859811704183484516925440e+38",   // max float32 (https://golang.org/pkg/math/#pkg-constants)
-				"f_double": "1.797693134862315708145274237317043567981e+308", // max float64
+				"fFloat":  "3.40282346638528859811704183484516925440e+38",   // max float32 (https://golang.org/pkg/math/#pkg-constants)
+				"fDouble": "1.797693134862315708145274237317043567981e+308", // max float64
 
-				"f_bool": "true",
+				"fBool": "true",
 
-				"f_bytes": "greetings",
+				"fBytes": "greetings",
 			},
 			expectProtoText: `f_string:"alphabet" f_int32:2147483647 f_sint32:2147483647 f_sfixed32:2147483647 f_uint32:4294967295 f_fixed32:4294967295 f_int64:9223372036854775807 f_sint64:9223372036854775807 f_sfixed64:9223372036854775807 f_uint64:18446744073709551615 f_fixed64:18446744073709551615 f_double:1.7976931348623157e+308 f_float:3.4028235e+38 f_bool:true f_bytes:"greetings"`,
 		},
 		{
 			label: "nested messages",
 			fields: map[string]string{
-				"f_string":                 "alphabet",
-				"f_child.f_child.f_string": "lexicon",
-				"f_int32":                  "5",
-				"f_child.f_child.f_double": "53.47",
-				"f_child.f_child.f_bool":   "true",
-				"f_child.f_bool":           "true",
+				"fString":               "alphabet",
+				"fChild.fChild.fString": "lexicon",
+				"fInt32":                "5",
+				"fChild.fChild.fDouble": "53.47",
+				"fChild.fChild.fBool":   "true",
+				"fChild.fBool":          "true",
 			},
 			expectProtoText: `f_child:{f_child:{f_string:"lexicon" f_bool:true f_double:53.47} f_bool:true} f_string:"alphabet" f_int32:5`,
 		},
 		{
 			label: "presence/zero values",
 			fields: map[string]string{
-				"f_string": "",
+				"fString": "",
 
-				"f_int32":    "0",
-				"f_sint32":   "0",
-				"f_sfixed32": "0",
+				"fInt32":    "0",
+				"fSint32":   "0",
+				"fSfixed32": "0",
 
-				"f_uint32":  "0",
-				"f_fixed32": "0",
+				"fUint32":  "0",
+				"fFixed32": "0",
 
-				"f_int64":    "0",
-				"f_sint64":   "0",
-				"f_sfixed64": "0",
+				"fInt64":    "0",
+				"fSint64":   "0",
+				"fSfixed64": "0",
 
-				"f_uint64":  "0",
-				"f_fixed64": "0",
+				"fUint64":  "0",
+				"fFixed64": "0",
 
-				"f_float":  "0",
-				"f_double": "0",
+				"fFloat":  "0",
+				"fDouble": "0",
 
-				"f_bool": "false",
+				"fBool": "false",
 
-				"f_bytes": "",
+				"fBytes": "",
 
-				"p_string": "",
-				"p_int32":  "0",
-				"p_double": "0",
-				"p_bool":   "false",
+				"pString": "",
+				"pInt32":  "0",
+				"pDouble": "0",
+				"pBool":   "false",
 			},
 			expectProtoText: `p_string:""  p_int32:0  p_double:0  p_bool:false`,
 		},
 		{
 			label: "presence/zero values in nested messages",
 			fields: map[string]string{
-				"f_child.f_string": "",
-				"f_child.f_float":  "0",
-				"f_child.f_double": "0",
-				"f_child.f_bool":   "false",
+				"fChild.fString": "",
+				"fChild.fFloat":  "0",
+				"fChild.fDouble": "0",
+				"fChild.fBool":   "false",
 
-				"f_child.p_string": "",
-				"f_child.p_float":  "0",
-				"f_child.p_double": "0",
-				"f_child.p_bool":   "false",
+				"fChild.pString": "",
+				"fChild.pFloat":  "0",
+				"fChild.pDouble": "0",
+				"fChild.pBool":   "false",
 
-				"p_child.f_string": "",
-				"p_child.f_float":  "0",
-				"p_child.f_double": "0",
-				"p_child.f_bool":   "false",
+				"pChild.fString": "",
+				"pChild.fFloat":  "0",
+				"pChild.fDouble": "0",
+				"pChild.fBool":   "false",
 
-				"p_child.p_string": "",
-				"p_child.p_float":  "0",
-				"p_child.p_double": "0",
-				"p_child.p_bool":   "false",
+				"pChild.pString": "",
+				"pChild.pFloat":  "0",
+				"pChild.pDouble": "0",
+				"pChild.pBool":   "false",
 
-				"f_child.f_child.f_string": "",
-				"f_child.f_child.f_double": "0",
-				"f_child.f_child.f_bool":   "false",
+				"fChild.fChild.fString": "",
+				"fChild.fChild.fDouble": "0",
+				"fChild.fChild.fBool":   "false",
 
-				"f_child.p_child.f_string": "",
-				"f_child.p_child.f_double": "0",
-				"f_child.p_child.f_bool":   "false",
+				"fChild.pChild.fString": "",
+				"fChild.pChild.fDouble": "0",
+				"fChild.pChild.fBool":   "false",
 
-				"p_child.f_child.f_string": "",
-				"p_child.f_child.f_double": "0",
-				"p_child.f_child.f_bool":   "false",
+				"pChild.fChild.fString": "",
+				"pChild.fChild.fDouble": "0",
+				"pChild.fChild.fBool":   "false",
 
-				"p_child.p_child.f_string": "",
-				"p_child.p_child.f_double": "0",
-				"p_child.p_child.f_bool":   "false",
+				"pChild.pChild.fString": "",
+				"pChild.pChild.fDouble": "0",
+				"pChild.pChild.fBool":   "false",
 			},
 			expectProtoText: `f_child:{f_child:{}  p_string:""  p_float:0  p_double:0  p_bool:false  p_child:{}}  p_child:{f_child:{}  p_string:""  p_float:0  p_double:0  p_bool:false  p_child:{}}`,
 		},
 		{
 			label: "default value only in nested message",
 			fields: map[string]string{
-				"f_child.f_string": "",
+				"fChild.fString": "",
 			},
 			expectProtoText: `f_child:{}`,
 		},
 		{
 			label: "default value only in optional nested message",
 			fields: map[string]string{
-				"p_child.f_string": "",
+				"pChild.fString": "",
 			},
 			expectProtoText: `p_child:{}`,
 		},
@@ -268,14 +285,14 @@ func TestPopulateFields(t *testing.T) {
 		{
 			label: "non-repeated fields",
 			fields: map[string][]string{
-				"f_string": []string{"alphabet"},
+				"fString": []string{"alphabet"},
 			},
 			expectProtoText: `f_string:"alphabet"`,
 		},
 		{
 			label: "repeated fields",
 			fields: map[string][]string{
-				"f_string": []string{"alphabet", "lexicon"},
+				"fString": []string{"alphabet", "lexicon"},
 			},
 			// TODO: Make Populate*Field*() work with repeated fields.
 			expectError: true,


### PR DESCRIPTION
Showcase will return an error if any field name is not properly cased, as a way of enforcing that generators are strict in the format they emit.

Includes positive and negative tests.
