### PR TITLE
chore: Add error identifiers and use them in tests

### DIFF
--- a/cmd/gapic-showcase/compliance_suite_errors_test.go
+++ b/cmd/gapic-showcase/compliance_suite_errors_test.go
@@ -39,7 +39,7 @@ func TestComplianceSuiteErrors(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	restRPCs := map[string][]prepRepeatDataTestFunc{
+	restRPCs := map[string][]prepRepeatDataNegativeTestFunc{
 		"Compliance.RepeatDataBodyInfo": {
 			prepRepeatDataBodyInfoNegativeTestRepeatedFields,
 			prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames,
@@ -68,7 +68,7 @@ func TestComplianceSuiteErrors(t *testing.T) {
 
 				for _, rpcPrep := range restTest {
 
-					prepName, verb, path, requestBody, err := rpcPrep(requestProto)
+					prepName, verb, path, requestBody, _, err := rpcPrep(requestProto)
 					if err != nil {
 						t.Errorf("%s error: %s", errorPrefix, err)
 					}
@@ -106,17 +106,19 @@ func TestComplianceSuiteErrors(t *testing.T) {
 	}
 }
 
-func prepRepeatDataBodyInfoNegativeTestRepeatedFields(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+type prepRepeatDataNegativeTestFunc func(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error)
+
+func prepRepeatDataBodyInfoNegativeTestRepeatedFields(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	resttools.JSONMarshaler.Replace(nil)
 	defer resttools.JSONMarshaler.Restore()
 
 	name = "Compliance.RepeatDataBodyInfo#NegativeTestRepeatedFields"
 	bodyBytes, err := resttools.ToJSON().Marshal(request.Info)
 	queryString := prepRepeatDataTestsQueryString(request, nil) // purposefully repeats query params, which should cause an error
-	return name, "POST", "/v1beta1/repeat:bodyinfo" + queryString, string(bodyBytes), err
+	return name, "POST", "/v1beta1/repeat:bodyinfo" + queryString, string(bodyBytes), "", err
 }
 
-func prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	resttools.JSONMarshaler.Replace(&protojson.MarshalOptions{
 		Multiline:       true,
 		AllowPartial:    false,
@@ -129,17 +131,17 @@ func prepRepeatDataBodyInfoNegativeTestSnakeCasedFieldNames(request *genproto.Re
 	name = "Compliance.RepeatDataBodyInfo#NegativeTestSnakeCasedFieldNames"
 	request.Info.FString += name
 	bodyBytes, err := resttools.ToJSON().Marshal(request.Info)
-	return name, "POST", "/v1beta1/repeat:bodyinfo", string(bodyBytes), err
+	return name, "POST", "/v1beta1/repeat:bodyinfo", string(bodyBytes), "", err
 }
 
-func prepRepeatDataQueryNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataQueryNegativeTestSnakeCasedFieldNames(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	name = "Compliance.RepeatDataQuery#NegativeTestSnakeCasedFieldNames"
 	queryParams := prepRepeatDataTestsQueryParams(request, nil, queryStringSnakeCaser) // this should cause an error
 	queryString := prepQueryString(queryParams)
-	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
+	return name, "GET", "/v1beta1/repeat:query" + queryString, body, "", err
 }
 
-func prepRepeatDataQueryNegativeTestNumericEnums(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataQueryNegativeTestNumericEnums(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	name = "Compliance.RepeatDataQuery#NegativeTestNumericEnums"
 	info := request.GetInfo()
 	badQueryParam := fmt.Sprintf("f_kingdom=%d", info.GetFKingdom()) // purposefully use a number, which should cause an error
@@ -151,10 +153,10 @@ func prepRepeatDataQueryNegativeTestNumericEnums(request *genproto.RepeatRequest
 	queryParams := append(prepRepeatDataTestsQueryParams(request, nil, queryStringLowerCamelCaser), badQueryParam)
 
 	queryString := prepQueryString(queryParams)
-	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
+	return name, "GET", "/v1beta1/repeat:query" + queryString, body, "", err
 }
 
-func prepRepeatDataQueryNegativeTestNumericOptionalEnums(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataQueryNegativeTestNumericOptionalEnums(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	name = "Compliance.RepeatDataQuery#NegativeTestNumericOptionalEnums"
 	info := request.GetInfo()
 	badQueryParam := fmt.Sprintf("p_kingdom=%d", info.GetPKingdom()) // purposefully use a number, which should cause an error
@@ -166,10 +168,10 @@ func prepRepeatDataQueryNegativeTestNumericOptionalEnums(request *genproto.Repea
 	queryParams := append(prepRepeatDataTestsQueryParams(request, nil, queryStringLowerCamelCaser), badQueryParam)
 
 	queryString := prepQueryString(queryParams)
-	return name, "GET", "/v1beta1/repeat:query" + queryString, body, err
+	return name, "GET", "/v1beta1/repeat:query" + queryString, body, "", err
 }
 
-func prepRepeatDataSimplePathNegativeTestEnum(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+func prepRepeatDataSimplePathNegativeTestEnum(request *genproto.RepeatRequest) (verb string, name string, path string, body string, expect string, err error) {
 	name = "Compliance.RepeatDataSimplePath#NegativeTestNumericEnum"
 	info := request.GetInfo()
 
@@ -193,5 +195,5 @@ func prepRepeatDataSimplePathNegativeTestEnum(request *genproto.RepeatRequest) (
 	path = fmt.Sprintf("/v1beta1/repeat/%s:simplepath", strings.Join(pathParts, "/"))
 
 	queryString := prepRepeatDataTestsQueryString(request, nonQueryParamNames)
-	return name, "GET", path + queryString, body, err
+	return name, "GET", path + queryString, body, "", err
 }

--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -174,7 +174,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				if len(excludedQueryParams) > 0 {
 					source.P("  excludedQueryParams := %#v", excludedQueryParams)
 					source.P("  if duplicates := resttools.KeysMatchPath(queryParams, excludedQueryParams); len(duplicates) > 0 {")
-					source.P(`    backend.Error(w, http.StatusBadRequest, " found keys that should not appear in query params: %%v", duplicates)`)
+					source.P(`    backend.Error(w, http.StatusBadRequest, "(QueryParamsInvalidFieldError) found keys that should not appear in query params: %%v", duplicates)`)
 					source.P("    return")
 					source.P("  }")
 				}

--- a/util/genrest/resttools/checkrequestformat.go
+++ b/util/genrest/resttools/checkrequestformat.go
@@ -70,7 +70,7 @@ func CheckFieldNames(payload jsonPayload) error {
 	for fieldName, value := range payload {
 		rune, _ := utf8.DecodeRuneInString(fieldName)
 		if strings.ContainsAny(fieldName, "_- ") || !unicode.IsLower(rune) {
-			return fmt.Errorf("%s field name is not lower-camel-cased; probably want be %q", fieldName, strcase.ToLowerCamel(fieldName))
+			return fmt.Errorf("%s field name is not lower-camel-cased; probably want be %q (BodyFieldNameIncorrectlyCasedError)", fieldName, strcase.ToLowerCamel(fieldName))
 		}
 		if nested, ok := value.(map[string]interface{}); ok {
 			if err := CheckFieldNames(nested); err != nil {

--- a/util/genrest/resttools/populatefield.go
+++ b/util/genrest/resttools/populatefield.go
@@ -153,7 +153,7 @@ func PopulateOneField(protoMessage proto.Message, fieldPath string, fieldValues 
 
 		case protoreflect.EnumKind:
 			if _, parseError = strconv.ParseFloat(value, 32); parseError == nil {
-				return fmt.Errorf("enum value %q for field path %q appears to be a number rather than an identifier", fieldName, fieldPath)
+				return fmt.Errorf("(EnumValueNotStringError) enum value %q for field path %q appears to be a number rather than an identifier", fieldName, fieldPath)
 			}
 			parsedValue := fieldDescriptor.Enum().Values().ByName(protoreflect.Name(value)).Number()
 			parseError, protoValue = nil, protoreflect.ValueOfEnum(parsedValue)
@@ -194,7 +194,7 @@ func parseBool(asString string) (bool, error) {
 // `foo_5_bar`).
 func findProtoFieldByJSONName(fieldName string, fields protoreflect.FieldDescriptors) (result protoreflect.FieldDescriptor, err error) {
 	if ToDottedLowerCamel(fieldName) != fieldName {
-		return nil, fmt.Errorf("field name %q is not lower-camel-cased", fieldName)
+		return nil, fmt.Errorf("(QueryParameterNameIncorrectlyCasedError)field name %q is not lower-camel-cased", fieldName)
 	}
 	numFields := fields.Len()
 	for idx := 0; idx < numFields; idx++ {


### PR DESCRIPTION
This ensures we're correctly exercising the expected errors.

(And this caught some cases in negative tests where the errors generated were not the ones intended!)