### PR TITLE
chore: fix multiline truncation of release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,10 @@ jobs:
         run: echo ::set-output name=raw_version::"${GITHUB_REF#refs/*/v}"
       - name: Get release information
         id: changes
-        run: echo ::set-output name=release_notes::"$(go run ./util/cmd/print_changes ${{ steps.tag.outputs.version }})"
+        # Need to escape new line characters in order to get multiline release notes.
+        run: |
+          notes=$(go run ./util/cmd/print_changes ${{ steps.tag.outputs.version }})
+          echo ::set-output name=release_notes::"${notes//$'\n'/'%0A'}"
     outputs:
       version: ${{ steps.tag.outputs.version }}
       raw_version: ${{ steps.raw_tag.outputs.raw_version }}


### PR DESCRIPTION
In order to capture multiline strings in `set-output` we need to escape the new line characters prior to providing it to `set-output`. I tested the commands to assign & parse the notes, but we will just have to see what happens with the Action on the next release.

Fixes #691 