### PR TITLE
chore: disable codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,10 +106,11 @@ jobs:
       run: go test ./...
     - name: Run server coverage
       run: go test ./server/... -coverprofile=coverage.txt -covermode=atomic
-    - uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.txt
-        flags: unittests
+    # Disabled indefinitely.
+    # - uses: codecov/codecov-action@v1
+    #   with:
+    #     files: ./coverage.txt
+    #     flags: unittests
   probes:
     needs: regenerate
     runs-on: ubuntu-latest


### PR DESCRIPTION
I thought I disabled this earlier, but I guess I didn't. I will roll any secrets in this repo again to be safe.