### PR TITLE
feat: Require incoming REST requests to have correct x-goog-api-client header

### DIFF
--- a/util/genrest/resttools/checkrequestformat.go
+++ b/util/genrest/resttools/checkrequestformat.go
@@ -31,10 +31,7 @@ import (
 
 // CheckRequestFormat verifies that the incoming request has the correct format in its body (via jsonReader) and in its HTTP headers.
 func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protoreflect.Message) error {
-	if err := CheckGAPICHeader(header); err != nil {
-		return err
-	}
-	if err := CheckRESTHeader(header); err != nil {
+	if err := CheckAPIClientHeader(header); err != nil {
 		return err
 	}
 

--- a/util/genrest/resttools/checkrequestformat.go
+++ b/util/genrest/resttools/checkrequestformat.go
@@ -31,6 +31,9 @@ import (
 
 // CheckRequestFormat verifies that the incoming request has the correct format in its body (via jsonReader) and in its HTTP headers.
 func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protoreflect.Message) error {
+	if err := CheckGAPICHeader(header); err != nil {
+		return err
+	}
 	if err := CheckRESTHeader(header); err != nil {
 		return err
 	}

--- a/util/genrest/resttools/checkrequestformat.go
+++ b/util/genrest/resttools/checkrequestformat.go
@@ -31,6 +31,10 @@ import (
 
 // CheckRequestFormat verifies that the incoming request has the correct format in its body (via jsonReader) and in its HTTP headers.
 func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protoreflect.Message) error {
+	if err := CheckRESTHeader(header); err != nil {
+		return err
+	}
+
 	if jsonReader == nil {
 		// TODO: above this if-statement, check for headers needed by all requests, not just those with a body
 		return nil
@@ -54,14 +58,6 @@ func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protor
 
 	enumFields := GetEnumFields(message)
 	return CheckJSONEnumFields(payload, enumFields)
-}
-
-// CheckContentType checks header to ensure the expected JSON content type is specified.
-func CheckContentType(header http.Header) error {
-	if content, ok := header[headerNameContentType]; !ok || len(content) != 1 || !strings.HasPrefix(strings.ToLower(strings.TrimSpace(content[0])), headerValueContentTypeJSON) {
-		return fmt.Errorf("(HeaderContentTypeError) did not find expected HTTP header %q: %q", headerNameContentType, headerValueContentTypeJSON)
-	}
-	return nil
 }
 
 // CheckFieldNames checks that the field names in the JSON request body are properly formatted
@@ -93,7 +89,7 @@ func CheckJSONEnumFields(payload jsonPayload, fieldsToCheck [][]protoreflect.Nam
 		}
 	}
 	if len(badFields) > 0 {
-		return fmt.Errorf("badly transcoded enum values in fields: %v", badFields)
+		return fmt.Errorf("(EnumEncodingError) badly transcoded enum values in fields: %v", badFields)
 	}
 	return nil
 }

--- a/util/genrest/resttools/checkrequestformat_test.go
+++ b/util/genrest/resttools/checkrequestformat_test.go
@@ -92,6 +92,15 @@ func TestCheckRequestFormat(t *testing.T) {
 			wantError: "(HeaderTransportRESTError)",
 		},
 		{
+			label: "no header gapic token",
+			json:  `{"fString": "hi"}`,
+			header: http.Header{
+				headerNameContentType: []string{headerValueContentTypeJSON},
+				headerNameAPIClient:   []string{"foo/1 rest/foo blah"},
+			},
+			wantError: "(HeaderClientGAPICError)",
+		},
+		{
 			label: "no content-type header",
 			json:  `{"fString": "hi"}`,
 			header: http.Header{

--- a/util/genrest/resttools/checkrequestformat_test.go
+++ b/util/genrest/resttools/checkrequestformat_test.go
@@ -158,7 +158,7 @@ func TestCheckRequestFormat(t *testing.T) {
 			PopulateRequestHeaders(request)
 		}
 		err = CheckRequestFormat(request.Body, request.Header, complianceData.ProtoReflect())
-		if (err != nil) != (len(testCase.wantError) > 0) {
+		if (err != nil) != (testCase.wantError != "") {
 			t.Errorf("test case %d[%q] CheckRequestFormat(): expected error==%v, got: %v", idx, testCase.label, testCase.wantError, err)
 			continue
 		}

--- a/util/genrest/resttools/headers.go
+++ b/util/genrest/resttools/headers.go
@@ -62,11 +62,13 @@ func CheckAPIClientHeader(header http.Header) error {
 	var haveREST, haveGAPIC bool
 	for _, token := range strings.Split(content[0], " ") {
 		trimmed := strings.TrimSpace(token)
-		if strings.HasPrefix(trimmed, headerValueTransportRESTPrefix) {
+		if !haveREST && strings.HasPrefix(trimmed, headerValueTransportRESTPrefix) {
 			haveREST = true
-		}
-		if strings.HasPrefix(trimmed, headerValueClientGAPICPrefix) {
+		} else if !haveGAPIC && strings.HasPrefix(trimmed, headerValueClientGAPICPrefix) {
 			haveGAPIC = true
+		} else {
+			// nothing changed
+			continue
 		}
 		if haveREST && haveGAPIC {
 			return nil


### PR DESCRIPTION
Showcase now requires incoming REST requests to have, in the header "x-goog-api-client", a token beginning with "rest/" and a token beginning with "gapic/"

This includes tests of this enforcement, and tighter (error-specific) tests for the content-encoding header enforcement as well.