### PR TITLE
fix: Allow mTLS to work over gRPC using cmux.

### DIFF
--- a/cmd/gapic-showcase/endpoint.go
+++ b/cmd/gapic-showcase/endpoint.go
@@ -85,8 +85,11 @@ func CreateAllEndpoints(config RuntimeConfig) Endpoint {
 	stdLog.Printf("Showcase listening on port: %s", config.port)
 
 	m := cmux.New(lis)
-	grpcListener := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpListener := m.Match(cmux.HTTP1Fast())
+	// cmux.Any() is needed below to get mTLS to work for
+	// gRPC, and that in turn means the order of the matchers matters. See
+	// https://github.com/open-telemetry/opentelemetry-collector/issues/2732
+	grpcListener := m.Match(cmux.Any())
 
 	backend := createBackends()
 	gRPCServer := newEndpointGRPC(grpcListener, config, backend)


### PR DESCRIPTION
This was leading to Showcase integration tests failures in Python when upgrading to the latest Showcase release (https://github.com/googleapis/gapic-generator-python/pull/918), which pulled in cmux-using Showcase for the first time in that repo.