### PR TITLE
feat!: have compliance service respond with full request message

### DIFF
--- a/cmd/gapic-showcase/compliance_suite_test.go
+++ b/cmd/gapic-showcase/compliance_suite_test.go
@@ -120,7 +120,7 @@ func TestComplianceSuite(t *testing.T) {
 				}
 
 				// Check for expected response.
-				if diff := cmp.Diff(response.GetInfo(), requestProto.GetInfo(), cmp.Comparer(proto.Equal)); diff != "" {
+				if diff := cmp.Diff(response.GetRequest(), requestProto, cmp.Comparer(proto.Equal)); diff != "" {
 					t.Errorf("%s unexpected response: got=-, want=+:%s\n   %s %s\n------------------------------\n",
 						errorPrefix, diff, verb, server.URL+path)
 				}

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -54,12 +54,12 @@ func TestRESTCalls(t *testing.T) {
 			verb: "POST",
 			path: "/v1beta1/repeat:body",
 			body: `{"info":{"fString":"jonas^ mila"}}`,
-			want: `{"info":{"fString":"jonas^ mila"}}`,
+			want: `{"request":{"info":{"fString":"jonas^ mila"}}}`,
 		},
 		{
 			verb: "GET",
 			path: "/v1beta1/repeat:query?info.fString=jonas+mila",
-			want: `{"info":{"fString":"jonas mila"}}`,
+			want: `{"request":{"info":{"fString":"jonas mila"}}}`,
 		},
 		{
 			verb: "GET",
@@ -67,7 +67,7 @@ func TestRESTCalls(t *testing.T) {
 
 			// TODO: Fix so that this returns an error, because `^` is not URL-escaped
 			statusCode: 200,
-			want:       `{"info":{"fString":"jonas^mila"}}`,
+			want:       `{"request":{"info":{"fString":"jonas^mila"}}}`,
 		},
 		{
 			verb:       "GET",
@@ -101,27 +101,32 @@ func TestRESTCalls(t *testing.T) {
 			body:     `{"info":{"fString":"jonas^ mila", "pDouble": 0}}`,
 			fullJSON: true,
 			want: `{
-                          "info": {
-                            "fString": "jonas^ mila",
-                            "fInt32": 0,
-                            "fSint32": 0,
-                            "fSfixed32": 0,
-                            "fUint32": 0,
-                            "fFixed32": 0,
-                            "fInt64": "0",
-                            "fSint64": "0",
-                            "fSfixed64": "0",
-                            "fUint64": "0",
-                            "fFixed64": "0",
-                            "fDouble": 0,
-                            "fFloat": 0,
-                            "fBool": false,
-                            "fBytes": "",
-                            "fKingdom": "LIFE_KINGDOM_UNSPECIFIED",
-                            "fChild": null,
-                            "pDouble": 0
+                          "request": {
+                            "name": "",
+                            "info": {
+                              "fString": "jonas^ mila",
+                              "fInt32": 0,
+                              "fSint32": 0,
+                              "fSfixed32": 0,
+                              "fUint32": 0,
+                              "fFixed32": 0,
+                              "fInt64": "0",
+                              "fSint64": "0",
+                              "fSfixed64": "0",
+                              "fUint64": "0",
+                              "fFixed64": "0",
+                              "fDouble": 0,
+                              "fFloat": 0,
+                              "fBool": false,
+                              "fBytes": "",
+                              "fKingdom": "LIFE_KINGDOM_UNSPECIFIED",
+                              "fChild": null,
+                              "pDouble": 0
+                            },
+                            "serverVerify": false
                           }
-                        }`,
+                        }
+                      `,
 		},
 	} {
 

--- a/schema/google/showcase/v1beta1/compliance.proto
+++ b/schema/google/showcase/v1beta1/compliance.proto
@@ -91,7 +91,7 @@ message RepeatRequest {
 }
 
 message RepeatResponse {
-  ComplianceData info = 1;
+  RepeatRequest request = 1;
 }
 
 // ComplianceSuite contains a set of requests that microgenerators should issue

--- a/server/services/compliance_service.go
+++ b/server/services/compliance_service.go
@@ -63,7 +63,7 @@ func (csi *complianceServerImpl) Repeat(ctx context.Context, in *pb.RepeatReques
 	if err := csi.requestMatchesExpectation(in); err != nil {
 		return nil, err
 	}
-	return &pb.RepeatResponse{Info: in.GetInfo()}, nil
+	return &pb.RepeatResponse{Request: in}, nil
 }
 
 func (csi *complianceServerImpl) RepeatDataBody(ctx context.Context, in *pb.RepeatRequest) (*pb.RepeatResponse, error) {

--- a/server/services/compliance_service_test.go
+++ b/server/services/compliance_service_test.go
@@ -60,7 +60,7 @@ func TestComplianceRepeats(t *testing.T) {
 		if err != nil {
 			t.Errorf("call %d: error: %s", idx, err)
 		}
-		if diff := cmp.Diff(response.GetInfo(), request.GetInfo(), cmp.Comparer(proto.Equal)); diff != "" {
+		if diff := cmp.Diff(response.GetRequest(), request, cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("call %d: got=-, want=+:%s", idx, diff)
 		}
 	}


### PR DESCRIPTION
This helps test, eg for` RepeatDataBodyInfo`, that top-level fields are
correctly encoded as query params. This is needed for testing REST for
GCE, which does *not* need to encode query params corresponding to
fields in nested sub-messages.

BREAKING CHANGE: This changes the structure (and hence wire format) of
the proto message `google.showcase.v1beta1.RepeatResponse`.