### PR TITLE
feat: check invalid requests: bodies for GET or DELETE; unmatched requests

### DIFF
--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -114,7 +114,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				source.P("    return")
 				source.P("  }")
 				source.P("")
-				source.P("  if err := resttools.CheckRequestFormat(&jsonReader, r.Header, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
+				source.P("  if err := resttools.CheckRequestFormat(&jsonReader, r, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
 				source.P(`    backend.Error(w, http.StatusBadRequest, "REST request failed format check: %%s", err)`)
 				source.P("    return")
 				source.P("  }")
@@ -146,7 +146,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				source.P("    return")
 				source.P("  }")
 				source.P("")
-				source.P("  if err := resttools.CheckRequestFormat(&jsonReader, r.Header, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
+				source.P("  if err := resttools.CheckRequestFormat(&jsonReader, r, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
 				source.P(`    backend.Error(w, http.StatusBadRequest, "REST request failed format check: %%s", err)`)
 				source.P("    return")
 				source.P("  }")
@@ -155,7 +155,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 				excludedQueryParams = append(excludedQueryParams, handler.RequestBodyFieldProtoName)
 
 			default:
-				source.P("  if err := resttools.CheckRequestFormat(nil, r.Header, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
+				source.P("  if err := resttools.CheckRequestFormat(nil, r, %s.ProtoReflect()); err != nil {", handler.RequestVariable)
 				source.P(`    backend.Error(w, http.StatusBadRequest, "REST request failed format check: %%s", err)`)
 				source.P("    return")
 				source.P("  }")

--- a/util/genrest/resttools/checkrequestformat.go
+++ b/util/genrest/resttools/checkrequestformat.go
@@ -30,13 +30,14 @@ import (
 )
 
 // CheckRequestFormat verifies that the incoming request has the correct format in its body (via jsonReader) and in its HTTP headers.
-func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protoreflect.Message) error {
+func CheckRequestFormat(jsonReader io.Reader, request *http.Request, message protoreflect.Message) error {
+	header := request.Header
+
 	if err := CheckAPIClientHeader(header); err != nil {
 		return err
 	}
 
 	if jsonReader == nil {
-		// TODO: above this if-statement, check for headers needed by all requests, not just those with a body
 		return nil
 	}
 
@@ -47,6 +48,10 @@ func CheckRequestFormat(jsonReader io.Reader, header http.Header, message protor
 	jsonBytes, err := ioutil.ReadAll(jsonReader)
 	if err != nil {
 		return err
+	}
+
+	if (request.Method == http.MethodGet || request.Method == http.MethodDelete) && request.Body != nil {
+		return fmt.Errorf("(UnexpectedRequestBodyError) non-zero body for HTTP %q", request.Method)
 	}
 
 	var payload jsonPayload


### PR DESCRIPTION
This returns an error response if GET or DELETE requests have a request body, or if we get a request that does not match any of the registered handlers.