### PR TITLE
feat: add Compliance RPCs that transcode to PUT and PATCH HTTP verbs.

### DIFF
--- a/client/gapic_metadata.json
+++ b/client/gapic_metadata.json
@@ -55,6 +55,16 @@
                 "RepeatDataBodyInfo"
               ]
             },
+            "RepeatDataBodyPatch": {
+              "methods": [
+                "RepeatDataBodyPatch"
+              ]
+            },
+            "RepeatDataBodyPut": {
+              "methods": [
+                "RepeatDataBodyPut"
+              ]
+            },
             "RepeatDataPathResource": {
               "methods": [
                 "RepeatDataPathResource"

--- a/cmd/gapic-showcase/compliance_suite_test.go
+++ b/cmd/gapic-showcase/compliance_suite_test.go
@@ -54,6 +54,8 @@ func TestComplianceSuite(t *testing.T) {
 	// each of their handlers invoking the correct GAPIC library method for the Showcase API.
 	restRPCs := map[string]prepRepeatDataTestFunc{
 		"Compliance.RepeatDataBody":                 prepRepeatDataBodyTest,
+		"Compliance.RepeatDataBodyPut":              prepRepeatDataBodyPutTest,
+		"Compliance.RepeatDataBodyPatch":            prepRepeatDataBodyPatchTest,
 		"Compliance.RepeatDataBodyInfo":             prepRepeatDataBodyInfoTest,
 		"Compliance.RepeatDataQuery":                prepRepeatDataQueryTest,
 		"Compliance.RepeatDataSimplePath":           prepRepeatDataSimplePathTest,
@@ -154,6 +156,16 @@ func prepRepeatDataBodyTest(request *genproto.RepeatRequest) (verb string, name 
 	name = "Compliance.RepeatDataBody"
 	bodyBytes, err := resttools.ToJSON().Marshal(request)
 	return "POST", name, "/v1beta1/repeat:body", string(bodyBytes), err
+}
+
+func prepRepeatDataBodyPutTest(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+	_, _, path, body, err = prepRepeatDataBodyTest(request)
+	return "PUT", "Compliance.RepeatDataBodyPut", path + "put", body, err
+}
+
+func prepRepeatDataBodyPatchTest(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {
+	_, _, path, body, err = prepRepeatDataBodyTest(request)
+	return "PATCH", "Compliance.RepeatDataBodyPatch", path + "patch", body, err
 }
 
 func prepRepeatDataBodyInfoTest(request *genproto.RepeatRequest) (verb string, name string, path string, body string, err error) {

--- a/schema/google/showcase/v1beta1/compliance.proto
+++ b/schema/google/showcase/v1beta1/compliance.proto
@@ -79,6 +79,23 @@ service Compliance {
       get: "/v1beta1/repeat/{info.f_string=first/*}/{info.f_child.f_string=second/**}:pathtrailingresource"
     };
   }
+
+  // This method echoes the ComplianceData request, using the HTTP PUT method.
+  rpc RepeatDataBodyPut(RepeatRequest) returns (RepeatResponse) {
+    option (google.api.http) = {
+      put: "/v1beta1/repeat:bodyput"
+      body: "*"
+    };
+  }
+
+  // This method echoes the ComplianceData request, using the HTTP PATCH method.
+  rpc RepeatDataBodyPatch(RepeatRequest) returns (RepeatResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta1/repeat:bodypatch"
+      body: "*"
+    };
+  }
+
 }
 
 message RepeatRequest {

--- a/server/services/compliance_service.go
+++ b/server/services/compliance_service.go
@@ -90,6 +90,14 @@ func (csi *complianceServerImpl) RepeatDataPathTrailingResource(ctx context.Cont
 	return csi.Repeat(ctx, in)
 }
 
+func (csi *complianceServerImpl) RepeatDataBodyPut(ctx context.Context, in *pb.RepeatRequest) (*pb.RepeatResponse, error) {
+	return csi.Repeat(ctx, in)
+}
+
+func (csi *complianceServerImpl) RepeatDataBodyPatch(ctx context.Context, in *pb.RepeatRequest) (*pb.RepeatResponse, error) {
+	return csi.Repeat(ctx, in)
+}
+
 // complianceSuiteBytes contains the contents of the compliance suite JSON file. This requires Go
 // 1.16. Note that embedding can only be applied to global variables at package scope.
 //go:embed compliance_suite.json

--- a/server/services/compliance_service_test.go
+++ b/server/services/compliance_service_test.go
@@ -55,6 +55,8 @@ func TestComplianceRepeats(t *testing.T) {
 		server.RepeatDataSimplePath,
 		server.RepeatDataPathResource,
 		server.RepeatDataPathTrailingResource,
+		server.RepeatDataBodyPut,
+		server.RepeatDataBodyPatch,
 	} {
 		response, err := rpc(context.Background(), request)
 		if err != nil {
@@ -66,7 +68,7 @@ func TestComplianceRepeats(t *testing.T) {
 	}
 }
 
-func TestMatchinComplianceSuiteRequests(t *testing.T) {
+func TestMatchingComplianceSuiteRequests(t *testing.T) {
 	server := &complianceServerImpl{}
 
 	info := &pb.ComplianceData{

--- a/server/services/compliance_suite.json
+++ b/server/services/compliance_suite.json
@@ -2,7 +2,7 @@
   "group": [
     {
       "name": "Fully working conversions, no resources",
-      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataBodyInfo"],
+      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataBodyInfo"],
       "requests": [
         {
           "name": "Basic data types",
@@ -145,7 +145,7 @@
     },
     {
       "name": "Fully working conversions, resources",
-      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataPathResource", "Compliance.RepeatDataPathTrailingResource"],
+      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataPathResource", "Compliance.RepeatDataPathTrailingResource"],
       "requests": [
         {
           "name": "Strings with slashes and values that resemble subsequent resource templates",
@@ -163,7 +163,7 @@
     },
     {
       "name": "Cases that apply to non-path requests",
-      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataQuery"],
+      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery"],
       "requests": [
         {
           "name": "Zero values for all fields",


### PR DESCRIPTION
These methods are now exercised in `compliance_suite.json`.

Includes tests.