### PR TITLE
feat: implement non-standard pagination returning maps of lists

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -93,6 +93,13 @@ service Echo {
     };
   }
 
+  rpc PagedExpandLegacyMapped(PagedExpandRequest) returns (PagedExpandLegacyMappedResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:pagedExpandLegacyMapped"
+      body: "*"
+    };
+  }
+
   // This method will wait for the requested amount of time and then return.
   // This method showcases how a client handles a request timeout.
   rpc Wait(WaitRequest) returns (google.longrunning.Operation) {
@@ -193,6 +200,18 @@ message PagedExpandLegacyRequest {
 message PagedExpandResponse {
   // The words that were expanded.
   repeated EchoResponse responses = 1;
+
+  // The next page token.
+  string next_page_token = 2;
+}
+
+message PagedExpandResponseList {
+  repeated string words = 1;
+}
+
+message PagedExpandLegacyMappedResponse {
+  // The words that were expanded, indexed by "forward" or "backward"
+  map<string, PagedExpandResponseList> alphabetized = 1;
 
   // The next page token.
   string next_page_token = 2;

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -210,7 +210,7 @@ message PagedExpandResponseList {
 }
 
 message PagedExpandLegacyMappedResponse {
-  // The words that were expanded, indexed by "forward" or "backward"
+  // The words that were expanded, indexed by their initial rune.
   map<string, PagedExpandResponseList> alphabetized = 1;
 
   // The next page token.

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -93,6 +93,11 @@ service Echo {
     };
   }
 
+  // This method returns a map containing lists of words that appear in the input, keyed by their
+  // initial character. The only words returned are the ones included in the current page,
+  // as determined by page_token and page_size, which both refer to the word indices in the
+  // input. This paging result consisting of a map of lists is a pattern used by some legacy
+  // APIs. New APIs should NOT use this pattern.
   rpc PagedExpandLegacyMapped(PagedExpandRequest) returns (PagedExpandLegacyMappedResponse) {
     option (google.api.http) = {
       post: "/v1beta1/echo:pagedExpandLegacyMapped"
@@ -205,12 +210,15 @@ message PagedExpandResponse {
   string next_page_token = 2;
 }
 
+// A list of words.
 message PagedExpandResponseList {
   repeated string words = 1;
 }
 
 message PagedExpandLegacyMappedResponse {
-  // The words that were expanded, indexed by their initial rune.
+  // The words that were expanded, indexed by their initial character.
+  // (-- aip.dev/not-precedent: This is a legacy, non-standard pattern that violates
+  //     aip.dev/158. Ordinarily, this should be a `repeated` field, as in PagedExpandResponse. --)
   map<string, PagedExpandResponseList> alphabetized = 1;
 
   // The next page token.

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -114,39 +114,16 @@ func (s *echoServerImpl) PagedExpandLegacy(ctx context.Context, in *pb.PagedExpa
 }
 
 func (s *echoServerImpl) PagedExpand(ctx context.Context, in *pb.PagedExpandRequest) (*pb.PagedExpandResponse, error) {
-	if in.GetPageSize() < 0 {
-		return nil, status.Error(codes.InvalidArgument, "The page size provided must not be negative.")
-	}
 	words := strings.Fields(in.GetContent())
 
-	start := int32(0)
-	if in.GetPageToken() != "" {
-		token, err := strconv.Atoi(in.GetPageToken())
-		token32 := int32(token)
-		if err != nil || token32 < 0 || token32 >= int32(len(words)) {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"Invalid page token: %s. Token must be within the range [0, %d)",
-				in.GetPageToken(),
-				len(words))
-		}
-		start = token32
+	start, end, nextToken, err := processPageTokens(len(words), in.GetPageSize(), in.GetPageToken())
+	if err != nil {
+		return nil, err
 	}
-
-	pageSize := in.GetPageSize()
-	if pageSize == 0 {
-		pageSize = int32(len(words))
-	}
-	end := min(start+pageSize, int32(len(words)))
 
 	responses := []*pb.EchoResponse{}
 	for _, word := range words[start:end] {
 		responses = append(responses, &pb.EchoResponse{Content: word})
-	}
-
-	nextToken := ""
-	if end < int32(len(words)) {
-		nextToken = strconv.Itoa(int(end))
 	}
 
 	echoTrailers(ctx)
@@ -154,6 +131,36 @@ func (s *echoServerImpl) PagedExpand(ctx context.Context, in *pb.PagedExpandRequ
 		Responses:     responses,
 		NextPageToken: nextToken,
 	}, nil
+}
+
+func processPageTokens(numElements int, pageSize int32, pageToken string) (start, end int32, nextToken string, err error) {
+	if pageSize < 0 {
+		return 0, 0, "", status.Error(codes.InvalidArgument, "the page size provided must not be negative.")
+	}
+
+	if pageToken != "" {
+		token, err := strconv.Atoi(pageToken)
+		token32 := int32(token)
+		if err != nil || token32 < 0 || token32 >= int32(numElements) {
+			return 0, 0, "", status.Errorf(
+				codes.InvalidArgument,
+				"invalid page token: %s. Token must be within the range [0, %d)",
+				pageToken,
+				numElements)
+		}
+		start = token32
+	}
+
+	if pageSize == 0 {
+		pageSize = int32(numElements)
+	}
+	end = min(start+pageSize, int32(numElements))
+
+	if end < int32(numElements) {
+		nextToken = strconv.Itoa(int(end))
+	}
+
+	return start, end, nextToken, nil
 }
 
 func min(x int32, y int32) int32 {

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -159,7 +159,6 @@ func (s *echoServerImpl) PagedExpandLegacyMapped(ctx context.Context, in *pb.Pag
 		}
 		if int32(idx) >= start && int32(idx) < end { // enforces #2
 			prev.Words = append(prev.Words, word)
-			alphabetized[key] = prev
 		}
 	}
 

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -142,9 +142,9 @@ func (s *echoServerImpl) PagedExpandLegacyMapped(ctx context.Context, in *pb.Pag
 	}
 
 	// Construct a map with the following properties:
-
+	//
 	// 1. The map has a one-rune string key corresponding to the first rune of EVERY word in words.
-	// 2. The value corresponding to the a given rune key is a list of only those words between
+	// 2. The value corresponding to a given rune key is a list of only those words between
 	// `start` and `end` whose first rune is that key.
 	// 3. Consequently, initial runes that only appear outside the [start,end) range will have
 	// empty list entries, even if they are non-empty in subsequent pages.

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -134,16 +134,6 @@ func (s *echoServerImpl) PagedExpand(ctx context.Context, in *pb.PagedExpandRequ
 	}, nil
 }
 
-// This is a WIP. It needs tests
-// Currently it does not compile: I get the following errors:
-//    % go run ./util/cmd/compile_protos && go test ./...
-//    # github.com/googleapis/gapic-showcase/client
-//    client/echo_client.go:545:62: undefined: genproto.PagedExpandLegacyMappedResponse_AlphabetizedEntry
-//    client/echo_client.go:914:14: undefined: genproto.PagedExpandLegacyMappedResponse_AlphabetizedEntry
-//    client/echo_client.go:929:65: undefined: genproto.PagedExpandLegacyMappedResponse_AlphabetizedEntry
-//    client/echo_client.go:939:79: undefined: genproto.PagedExpandLegacyMappedResponse_AlphabetizedEntry
-//    client/echo_client.go:940:12: undefined: genproto.PagedExpandLegacyMappedResponse_AlphabetizedEntry
-// The symbols on the right are indeed not in the echo.pb.go file.
 func (s *echoServerImpl) PagedExpandLegacyMapped(ctx context.Context, in *pb.PagedExpandRequest) (*pb.PagedExpandLegacyMappedResponse, error) {
 	words := strings.Fields(in.GetContent())
 	start, end, nextToken, err := processPageTokens(len(words), in.GetPageSize(), in.GetPageToken())

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -572,7 +572,7 @@ func TestPagedExpandLegacyMapped_invalidArgs(t *testing.T) {
 		_, err := server.PagedExpandLegacyMapped(context.Background(), in)
 		s, _ := status.FromError(err)
 		if s.Code() != codes.InvalidArgument {
-			t.Errorf("PagedExpand() expected error code: %d, got error code %d",
+			t.Errorf("PagedExpandLegacyMapped() expected error code: %d, got error code %d",
 				codes.InvalidArgument, s.Code())
 		}
 	}
@@ -597,7 +597,6 @@ func TestPagedExpandLegacyMapped(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			&pb.PagedExpandRequest{PageSize: 1, Content: text},
 			&pb.PagedExpandLegacyMappedResponse{
@@ -612,7 +611,6 @@ func TestPagedExpandLegacyMapped(t *testing.T) {
 				NextPageToken: "1",
 			},
 		},
-
 		{
 			&pb.PagedExpandRequest{PageSize: 4, PageToken: "2", Content: text},
 			&pb.PagedExpandLegacyMappedResponse{
@@ -627,7 +625,6 @@ func TestPagedExpandLegacyMapped(t *testing.T) {
 				NextPageToken: "6",
 			},
 		},
-
 		{
 			&pb.PagedExpandRequest{PageSize: 4, PageToken: "8", Content: text},
 			&pb.PagedExpandLegacyMappedResponse{
@@ -652,7 +649,7 @@ func TestPagedExpandLegacyMapped(t *testing.T) {
 			t.Error(err)
 		}
 		if !proto.Equal(test.out, out) {
-			t.Errorf("PagedExpand with input '%q':\n  expected: %#v\n       got: %#v\n",
+			t.Errorf("PagedExpandLegacyMapped with input '%q':\n  expected: %#v\n       got: %#v\n",
 				test.in.String(), test.out.String(), out.String())
 		}
 		mockStream.verify(err == nil)

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -461,7 +461,7 @@ func TestPagedExpand(t *testing.T) {
 			t.Error(err)
 		}
 		if !proto.Equal(test.out, out) {
-			t.Errorf("PagedExpand with input '%q', expected: %q, got: %q",
+			t.Errorf("PagedExpand with input %q, expected: %q, got: %q",
 				test.in.String(), test.out.String(), out.String())
 		}
 		mockStream.verify(err == nil)
@@ -552,7 +552,7 @@ func TestPagedExpandLegacy(t *testing.T) {
 			t.Error(err)
 		}
 		if !proto.Equal(test.out, out) {
-			t.Errorf("PagedExpandLegacy with input '%q', expected: %q, got: %q",
+			t.Errorf("PagedExpandLegacy with input %q, expected: %q, got: %q",
 				test.in.String(), test.out.String(), out.String())
 		}
 		mockStream.verify(err == nil)
@@ -649,7 +649,7 @@ func TestPagedExpandLegacyMapped(t *testing.T) {
 			t.Error(err)
 		}
 		if !proto.Equal(test.out, out) {
-			t.Errorf("PagedExpandLegacyMapped with input '%q':\n  expected: %#v\n       got: %#v\n",
+			t.Errorf("PagedExpandLegacyMapped with input %q:\n  expected: %#v\n       got: %#v\n",
 				test.in.String(), test.out.String(), out.String())
 		}
 		mockStream.verify(err == nil)

--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -84,6 +84,15 @@ func CompileProtos(version string) {
 	}
 	Execute(command...)
 
+	// Remove CLI file that cannot deal with maps as paged responses.
+	//
+	// TODO: Remove this once the CLI generator can accommodate paging calls that return maps.
+	command = []string{
+		"rm",
+		filepath.Join(pwd, "cmd", "gapic-showcase", "paged-expand-legacy-mapped.go"),
+	}
+	Execute(command...)
+
 	// Fix some generated errors.
 	fixes := []struct {
 		file string

--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -68,7 +68,6 @@ func CompileProtos(version string) {
 		"--go_gapic_opt=metadata",
 		"--go_rest_server_out=" + filepath.Join("server", "genrest"),
 		"--go_out=plugins=grpc:" + outDir,
-		"--plugin=/tmp/bin/protoc-gen-go_gapic", // REMOVE THIS
 	}
 	Execute(append(command, files...)...)
 
@@ -81,15 +80,6 @@ func CompileProtos(version string) {
 		tempClient,
 		tempServer,
 		pwd,
-	}
-	Execute(command...)
-
-	// Remove CLI file that cannot deal with maps as paged responses.
-	//
-	// TODO: Remove this once the CLI generator can accommodate paging calls that return maps.
-	command = []string{
-		"rm",
-		filepath.Join(pwd, "cmd", "gapic-showcase", "paged-expand-legacy-mapped.go"),
 	}
 	Execute(command...)
 
@@ -116,8 +106,10 @@ func CompileProtos(version string) {
 
 		// Remove the backup file.
 		Execute("rm", fmt.Sprintf("%s.bak", f.file))
-		Execute("rm", "-f", "cmd/gapic-showcase/paged-expand-legacy.go")
 	}
+
+	// TODO: Remove this once the CLI generator supports mapped pagination responses.
+	Execute("rm", "-f", "cmd/gapic-showcase/paged-expand-legacy.go")
 
 	// Format generated output
 	Execute("go", "fmt", "./...")

--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -68,6 +68,7 @@ func CompileProtos(version string) {
 		"--go_gapic_opt=metadata",
 		"--go_rest_server_out=" + filepath.Join("server", "genrest"),
 		"--go_out=plugins=grpc:" + outDir,
+		"--plugin=/tmp/bin/protoc-gen-go_gapic", // REMOVE THIS
 	}
 	Execute(append(command, files...)...)
 


### PR DESCRIPTION
This PR is in draft mode because it contains a hack in `compile_protos.go` to use a locally-built Go GAPIC generator protobuf plugin. Once the GAPIC generator is released with code to either ignore or support mapped paging responses, that hack can be removed.

