### PR TITLE
chore: support skipping TS smoke test

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,6 @@ branchProtectionRules:
     - 'tests'
     - 'probes'
     - 'protobufjs-load-test'
-    - 'typescript-smoke-test'
     - 'cla/google'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,7 @@ jobs:
         echo "REST status code: $STATUSCODE"
         [ $STATUSCODE = "200" ]  && [ GRPC_EXIT_CODE != 0 ]
   typescript-smoke-test:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip: typescript-smoke-test')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Adds a conditional to the `typescript-smoke-test` job that allows it to be skipped via a PR label. Also removes it as a required check in the sync-repo-settings.