### PR TITLE
Implement incremental sends for server streaming

### DIFF
--- a/util/genrest/goviewcreator_test.go
+++ b/util/genrest/goviewcreator_test.go
@@ -88,6 +88,7 @@ func TestNamer(t *testing.T) {
 }
 
 func TestConstructStreamingServer(t *testing.T) {
+	return // FIXME: This is for development only
 	fileImports := map[string]string{}
 	helperSources := sourceMap{}
 

--- a/util/genrest/goviewcreator_test.go
+++ b/util/genrest/goviewcreator_test.go
@@ -88,7 +88,6 @@ func TestNamer(t *testing.T) {
 }
 
 func TestConstructStreamingServer(t *testing.T) {
-	return // FIXME: This is for development only
 	fileImports := map[string]string{}
 	helperSources := sourceMap{}
 
@@ -100,7 +99,7 @@ func TestConstructStreamingServer(t *testing.T) {
 			ResponseType:        "AuthorEntry",
 		},
 		fileImports, helperSources)
-	if got, want := len(helperSources), 2; got != want {
+	if got, want := len(helperSources), 1; got != want {
 		t.Errorf("unexpected length of helperSources: got %d, want %d", got, want)
 	}
 
@@ -112,7 +111,7 @@ func TestConstructStreamingServer(t *testing.T) {
 			ResponseType:        "TitleEntry",
 		},
 		fileImports, helperSources)
-	if got, want := len(helperSources), 3; got != want {
+	if got, want := len(helperSources), 2; got != want {
 		t.Errorf("unexpected length of helperSources: got %d, want %d", got, want)
 	}
 
@@ -124,7 +123,7 @@ func TestConstructStreamingServer(t *testing.T) {
 			ResponseType:        "AudioEntry",
 		},
 		fileImports, helperSources)
-	if got, want := len(helperSources), 5; got != want {
+	if got, want := len(helperSources), 3; got != want {
 		t.Errorf("unexpected length of helperSources: got %d, want %d", got, want)
 	}
 
@@ -136,7 +135,7 @@ func TestConstructStreamingServer(t *testing.T) {
 			ResponseType:        "VideoEntry",
 		},
 		fileImports, helperSources)
-	if got, want := len(helperSources), 6; got != want {
+	if got, want := len(helperSources), 4; got != want {
 		t.Errorf("unexpected length of helperSources: got %d, want %d", got, want)
 	}
 

--- a/util/genrest/resttools/server_streamer.go
+++ b/util/genrest/resttools/server_streamer.go
@@ -1,0 +1,102 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resttools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// ServerStreamer implements REST server streaming functionality that can be called by streaming
+// RPCs to stream their responses over HTTP/JSON. The messages are encoded such that once th stream
+// is finished, the total payload represents a properly formed JSON array of objects. In order to
+// ensure this, users must call the End() method to terminate the stream properly, typically by
+// using `defer`.
+type ServerStreamer struct {
+	output    http.ResponseWriter
+	marshaler *protojson.MarshalOptions
+	flusher   http.Flusher
+	grpc.ServerStream
+	started bool
+}
+
+// NewServerStreamer returns a ServerStreamer instance initialized to write to responseWriter. Users
+// must call the End() method to terminate the stream properly, typically by using `defer`.
+func NewServerStreamer(responseWriter http.ResponseWriter) (*ServerStreamer, error) {
+	if responseWriter == nil {
+		return nil, fmt.Errorf("error: responseWriter provided is nil")
+	}
+
+	flusher, ok := responseWriter.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("error: responseWriter provided does not implement http.Flusher")
+	}
+
+	streamer := &ServerStreamer{
+		output:    responseWriter,
+		flusher:   flusher,
+		marshaler: ToJSON(),
+	}
+
+	return streamer, nil
+}
+
+// Send sends `response` over the REST stream by writing the message and then flushing the writer.
+func (streamer *ServerStreamer) Send(response proto.Message) error {
+	json, err := streamer.marshaler.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("error json-encoding response: %s", err.Error())
+	}
+
+	var prefix []byte
+	switch streamer.started {
+	case false:
+		prefix = []byte("[")
+		streamer.started = true
+	case true:
+		prefix = []byte(",")
+	}
+
+	if _, err := streamer.output.Write(append(prefix, json...)); err != nil {
+		return fmt.Errorf("error writing streamed json message: %s", err.Error())
+	}
+
+	streamer.flusher.Flush()
+
+	return nil
+}
+
+// End terminates the REST stream by sending the trailing bytes (the closing bracket for the array).
+func (streamer *ServerStreamer) End() error {
+	if !streamer.started {
+		return nil
+	}
+
+	if _, err := streamer.output.Write([]byte("]")); err != nil {
+		return fmt.Errorf("error terminating json stream: %s", err.Error())
+	}
+
+	return nil
+}
+
+// Context is needed to satisfy grpc.ServerStream.
+func (streamer *ServerStreamer) Context() context.Context {
+	return context.Background()
+}

--- a/util/genrest/resttools/server_streamer_test.go
+++ b/util/genrest/resttools/server_streamer_test.go
@@ -1,0 +1,111 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resttools
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type wireBuffer struct {
+	bytes.Buffer
+	chunks []string
+}
+
+func (wb *wireBuffer) Flush() {
+	wb.chunks = append(wb.chunks, wb.String())
+	wb.Reset()
+}
+
+func TestServerStreamer(t *testing.T) {
+	for idx, testCase := range []struct {
+		name           string
+		messages       []string
+		expectedChunks []string
+	}{
+		{
+			name:     "Single chunk",
+			messages: []string{"greetings"},
+			expectedChunks: []string{
+				"[greetings",
+				"]",
+			},
+		},
+		{
+			name:     "Two chunks",
+			messages: []string{"greetings", "  earthling"},
+			expectedChunks: []string{
+				"[greetings",
+				",  earthling",
+				"]",
+			},
+		},
+		{
+			name:     "Many chunks",
+			messages: []string{"greetings", "  people", "of ", "Earth"},
+			expectedChunks: []string{
+				"[greetings",
+				",  people",
+				",of ",
+				",Earth",
+				"]",
+			},
+		},
+		{
+			name:           "No chunks",
+			messages:       []string{},
+			expectedChunks: nil,
+		},
+		{
+			name:           "Single empty chunk",
+			messages:       []string{""},
+			expectedChunks: nil,
+		},
+		{
+			name:     "Intermediate empty chunk",
+			messages: []string{"greetings", "", "earthlings"},
+			expectedChunks: []string{
+				"[greetings",
+				",earthlings",
+				"]",
+			},
+		},
+	} {
+		label := fmt.Sprintf("[%d:%s]", idx, testCase.name)
+
+		wire := &wireBuffer{}
+		streamer, err := NewServerStreamer(wire)
+		if err != nil {
+			t.Fatalf("%s: could not construct ServerStreamer: %s", label, err)
+		}
+
+		for msgIdx, msg := range testCase.messages {
+			if err := streamer.sendJSONArrayChunk([]byte(msg)); err != nil {
+				t.Errorf("%s: error sending message #%d (%q): %s", label, msgIdx, msg, err)
+				break
+			}
+		}
+		if err := streamer.End(); err != nil {
+			t.Errorf("%s: error ending stream: %s", label, err)
+		}
+
+		if got, want := wire.chunks, testCase.expectedChunks; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: did not received expected chunks\n== got ===\n%#v\n== want ==\n%#v\n",
+				label, got, want)
+		}
+	}
+}

--- a/util/genrest/testdata/TestConstructServerStreamer.go.baseline
+++ b/util/genrest/testdata/TestConstructServerStreamer.go.baseline
@@ -1,110 +1,44 @@
-// Catalog_BaseServerStreamer contains the basic accumulation and emit functionality to help handle all server streaming RPCs in the Catalog service.
-type Catalog_BaseServerStreamer struct{
-   responses []string
-   initialization sync.Once
-   marshaler      *protojson.MarshalOptions
- 
-   grpc.ServerStream
- }
-
-func (streamer *Catalog_BaseServerStreamer) accumulate(response proto.Message) error {
-   streamer.initialization.Do(streamer.initialize)
-   json, err := streamer.marshaler.Marshal(response)
-   if err != nil {
-     return fmt.Errorf("error json-encoding response: %s", err.Error())
-   }
-   streamer.responses = append(streamer.responses, string(json))
-   return nil
-}
-
-// ListJSON returns a list of all the accumulated responses, in JSON format.
-func (streamer *Catalog_BaseServerStreamer) ListJSON() string {
-   return fmt.Sprintf("[%s]", strings.Join(streamer.responses, ",\n"))
-}
-
-func (streamer *Catalog_BaseServerStreamer) initialize() {
-   streamer.marshaler = resttools.ToJSON()
-}
-
-func (streamer *Catalog_BaseServerStreamer) Context() context.Context {
-   return context.Background()
-}
-
-
 // Catalog_StreamAuthorsServer implements catalogpb.Catalog_StreamAuthorsServer to provide server-side streaming over REST, returning all the
 // individual responses as part of a long JSON list.
 type Catalog_StreamAuthorsServer struct{
-   Catalog_BaseServerStreamer
+   *resttools.ServerStreamer
 }
 
  // Send accumulates a response to be fetched later as part of response list returned over REST.
 func (streamer *Catalog_StreamAuthorsServer) Send(response *responsepb.AuthorEntry) error {
-  return streamer.accumulate(response)
+  return streamer.ServerStreamer.Send(response)
 }
 
 // Catalog_StreamTitlesServer implements catalogpb.Catalog_StreamTitlesServer to provide server-side streaming over REST, returning all the
 // individual responses as part of a long JSON list.
 type Catalog_StreamTitlesServer struct{
-   Catalog_BaseServerStreamer
+   *resttools.ServerStreamer
 }
 
  // Send accumulates a response to be fetched later as part of response list returned over REST.
 func (streamer *Catalog_StreamTitlesServer) Send(response *responsepb.TitleEntry) error {
-  return streamer.accumulate(response)
+  return streamer.ServerStreamer.Send(response)
 }
-
-// Media_BaseServerStreamer contains the basic accumulation and emit functionality to help handle all server streaming RPCs in the Media service.
-type Media_BaseServerStreamer struct{
-   responses []string
-   initialization sync.Once
-   marshaler      *protojson.MarshalOptions
- 
-   grpc.ServerStream
- }
-
-func (streamer *Media_BaseServerStreamer) accumulate(response proto.Message) error {
-   streamer.initialization.Do(streamer.initialize)
-   json, err := streamer.marshaler.Marshal(response)
-   if err != nil {
-     return fmt.Errorf("error json-encoding response: %s", err.Error())
-   }
-   streamer.responses = append(streamer.responses, string(json))
-   return nil
-}
-
-// ListJSON returns a list of all the accumulated responses, in JSON format.
-func (streamer *Media_BaseServerStreamer) ListJSON() string {
-   return fmt.Sprintf("[%s]", strings.Join(streamer.responses, ",\n"))
-}
-
-func (streamer *Media_BaseServerStreamer) initialize() {
-   streamer.marshaler = resttools.ToJSON()
-}
-
-func (streamer *Media_BaseServerStreamer) Context() context.Context {
-   return context.Background()
-}
-
 
 // Media_StreamAudioServer implements mediapb.Media_StreamAudioServer to provide server-side streaming over REST, returning all the
 // individual responses as part of a long JSON list.
 type Media_StreamAudioServer struct{
-   Media_BaseServerStreamer
+   *resttools.ServerStreamer
 }
 
  // Send accumulates a response to be fetched later as part of response list returned over REST.
 func (streamer *Media_StreamAudioServer) Send(response *responsepb.AudioEntry) error {
-  return streamer.accumulate(response)
+  return streamer.ServerStreamer.Send(response)
 }
 
 // Media_StreamVideoServer implements mediapb.Media_StreamVideoServer to provide server-side streaming over REST, returning all the
 // individual responses as part of a long JSON list.
 type Media_StreamVideoServer struct{
-   Media_BaseServerStreamer
+   *resttools.ServerStreamer
 }
 
  // Send accumulates a response to be fetched later as part of response list returned over REST.
 func (streamer *Media_StreamVideoServer) Send(response *responsepb.VideoEntry) error {
-  return streamer.accumulate(response)
+  return streamer.ServerStreamer.Send(response)
 }
 


### PR DESCRIPTION
This causes incremental sends of streamed messages via chunked encoding. 

CLI experience, using `curl --raw` to see the chunk delimiters:

```
❯ curl --raw -i -X POST http://localhost:7469/v1beta1/echo:expand -d'{"content":"it was a dark and stormy night"}' -H "Content-Type: application/json" -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0"

HTTP/1.1 200 OK
Date: Fri, 22 Oct 2021 02:47:36 GMT
Content-Type: text/plain; charset=utf-8
Transfer-Encoding: chunked

35
[{
  "content":  "it",
  "severity":  "UNNECESSARY"
}
36
,{
  "content":  "was",
  "severity":  "UNNECESSARY"
}
34
,{
  "content":  "a",
  "severity":  "UNNECESSARY"
}
37
,{
  "content":  "dark",
  "severity":  "UNNECESSARY"
}
36
,{
  "content":  "and",
  "severity":  "UNNECESSARY"
}
39
,{
  "content":  "stormy",
  "severity":  "UNNECESSARY"
}
38
,{
  "content":  "night",
  "severity":  "UNNECESSARY"
}
1
]
0
```
