### PR TITLE
fix!: add `parent` to method signature for `Messaging.SearchBlurbs()`

### DIFF
--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -153,7 +153,7 @@ service Messaging {
       response_type: "SearchBlurbsResponse"
       metadata_type: "SearchBlurbsMetadata"
     };
-    option (google.api.method_signature) = "query";
+    option (google.api.method_signature) = "parent,query";
   }
 
   // This returns a stream that emits the blurbs that are created for a


### PR DESCRIPTION
BREAKING CHANGE: this changes the flattened method signature for the Messaging.SearchBlurbs() RPC to require  a `parent` parameter.

Without this change, the flattened method does not work, as the required field parent is not supplied.