### PR TITLE
feat: add ability to echo headers & sample routing annotations on echo method

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -23,9 +23,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #
 http_archive(
   name = "com_google_googleapis",
-  strip_prefix = "googleapis-b4b8eda2f253cbdab358d2b280468fe5f35a4ed9",
-  urls = ["https://github.com/googleapis/googleapis/archive/b4b8eda2f253cbdab358d2b280468fe5f35a4ed9.zip"],
-  sha256 = "7696de036faaccd30c2748e9709c31e6abd6997bcf4648bd43b24d5e5e38ba7a"
+  strip_prefix = "googleapis-8c42b6d576d865d40398cd67ed37215748721868",
+  urls = ["https://github.com/googleapis/googleapis/archive/8c42b6d576d865d40398cd67ed37215748721868.zip"],
+  sha256 = "a17552af336b93a1de63ac67189bd586ad1b8f44abb1dcea9ee5433d8eed5feb"
 )
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 switched_rules_by_language(name = "com_google_googleapis_imports", grpc = True)

--- a/client/doc.go
+++ b/client/doc.go
@@ -110,7 +110,9 @@ func checkDisableDeadlines() (bool, error) {
 
 // DefaultAuthScopes reports the default set of authentication scopes to use with this package.
 func DefaultAuthScopes() []string {
-	return []string{}
+	return []string{
+		"",
+	}
 }
 
 // versionGo returns the Go runtime version. The returned string

--- a/client/echo_client.go
+++ b/client/echo_client.go
@@ -164,7 +164,9 @@ type internalEchoClient interface {
 // side streaming, client side streaming, and bidirectional streaming. This
 // service also exposes methods that explicitly implement server delay, and
 // paginated calls. Set the ‘showcase-trailer’ metadata key on any method
-// to have the values echoed in the response trailers.
+// to have the values echoed in the response trailers. Set the
+// ‘x-goog-request-params’ metadata key on any method to have the values
+// echoed in the response headers.
 type EchoClient struct {
 	// The internal transport-dependent client.
 	internalClient internalEchoClient
@@ -349,7 +351,9 @@ type echoGRPCClient struct {
 // side streaming, client side streaming, and bidirectional streaming. This
 // service also exposes methods that explicitly implement server delay, and
 // paginated calls. Set the ‘showcase-trailer’ metadata key on any method
-// to have the values echoed in the response trailers.
+// to have the values echoed in the response trailers. Set the
+// ‘x-goog-request-params’ metadata key on any method to have the values
+// echoed in the response headers.
 func NewEchoClient(ctx context.Context, opts ...option.ClientOption) (*EchoClient, error) {
 	clientOpts := defaultEchoGRPCClientOptions()
 	if newEchoClientHook != nil {

--- a/cmd/gapic-showcase/echo.go
+++ b/cmd/gapic-showcase/echo.go
@@ -49,6 +49,10 @@ func init() {
 
 	EchoCmd.Flags().StringVar(&EchoInputSeverity, "severity", "", "The severity to be echoed by the server.")
 
+	EchoCmd.Flags().StringVar(&EchoInput.Header, "header", "", "Optional. This field can be set to test the...")
+
+	EchoCmd.Flags().StringVar(&EchoInput.OtherHeader, "other_header", "", "Optional. This field can be set to test the...")
+
 	EchoCmd.Flags().StringVar(&EchoInputResponse, "response", "", "Choices: content, error")
 
 	EchoCmd.Flags().StringVar(&EchoFromFile, "from_file", "", "Absolute path to JSON file containing request payload")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/googleapis/gapic-showcase
 require (
 	cloud.google.com/go v0.100.2
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.7
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/googleapis/grpc-fallback-go v0.1.4
 	github.com/gorilla/mux v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.65.0
-	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368
+	google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,9 @@ google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211206160659-862468c7d6e0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211221195035-429b39de9b1c/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 h1:Et6SkiuvnBn+SgrSYXs/BrUpGB4mbdwt4R3vaPIlicA=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0 h1:aCsSLXylHWFno0r4S3joLpiaWayvqd2Mn4iSvx4WZZc=
+google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
+import "google/api/routing.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
@@ -33,7 +34,9 @@ option ruby_package = "Google::Showcase::V1Beta1";
 // side streaming, client side streaming, and bidirectional streaming. This
 // service also exposes methods that explicitly implement server delay, and
 // paginated calls. Set the 'showcase-trailer' metadata key on any method
-// to have the values echoed in the response trailers.
+// to have the values echoed in the response trailers. Set the 
+// 'x-goog-request-params' metadata key on any method to have the values
+// echoed in the response headers.
 service Echo {
   // This service is meant to only run locally on the port 7469 (keypad digits
   // for "show").
@@ -44,6 +47,39 @@ service Echo {
     option (google.api.http) = {
       post: "/v1beta1/echo:echo"
       body: "*"
+    };
+    option (google.api.routing) = {
+      routing_parameters{
+        field: "header"
+      }
+      routing_parameters{
+        field: "header"
+        path_template: "{routing_id=**}"
+      }
+      routing_parameters{
+        field: "header"
+        path_template: "{table_name=regions/*/zones/*/**}"
+      }
+      routing_parameters{
+        field: "header"
+        path_template: "{super_id=projects/*}/**"
+      }
+      routing_parameters{
+        field: "header"
+        path_template: "{table_name=projects/*/instances/*/**}"
+      }
+      routing_parameters{
+        field: "header"
+        path_template: "projects/*/{instance_id=instances/*}/**"
+      }
+      routing_parameters{
+        field: "other_header"
+        path_template: "{baz=**}"
+      }
+      routing_parameters{
+        field: "other_header"
+        path_template: "{qux=projects/*}/**"
+      }
     };
   }
 
@@ -153,6 +189,12 @@ message EchoRequest {
 
   // The severity to be echoed by the server.
   Severity severity = 3;
+
+  // Optional. This field can be set to test the routing annotation on the Echo method.
+  string header = 4;
+
+  // Optional. This field can be set to test the routing annotation on the Echo method.
+  string other_header = 5;
 }
 
 // The response message for the Echo methods.

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -17,6 +17,7 @@ package services
 import (
 	"context"
 	"io"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -46,21 +47,26 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 	if err != nil {
 		return nil, err
 	}
+	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return &pb.EchoResponse{Content: in.GetContent(), Severity: in.GetSeverity()}, nil
 }
 
 func (s *echoServerImpl) Expand(in *pb.ExpandRequest, stream pb.Echo_ExpandServer) error {
 	for _, word := range strings.Fields(in.GetContent()) {
+		log.Printf("range_stream: %v:", stream)
 		err := stream.Send(&pb.EchoResponse{Content: word})
 		if err != nil {
+			log.Printf("err_stream: %v:", stream)
 			return err
 		}
 	}
+	echoStreamingHeaders(stream)
 	if in.GetError() != nil {
 		return status.ErrorProto(in.GetError())
 	}
 	echoStreamingTrailers(stream)
+	log.Printf("ending_stream: %v:", stream)
 	return nil
 }
 
@@ -70,6 +76,7 @@ func (s *echoServerImpl) Collect(stream pb.Echo_CollectServer) error {
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
+			echoStreamingHeaders(stream)
 			echoStreamingTrailers(stream)
 			return stream.SendAndClose(&pb.EchoResponse{Content: strings.Join(resp, " ")})
 		}
@@ -101,6 +108,7 @@ func (s *echoServerImpl) Chat(stream pb.Echo_ChatServer) error {
 		if s != nil {
 			return s
 		}
+		echoStreamingHeaders(stream)
 		stream.Send(&pb.EchoResponse{Content: req.GetContent()})
 	}
 }
@@ -127,6 +135,7 @@ func (s *echoServerImpl) PagedExpand(ctx context.Context, in *pb.PagedExpandRequ
 		responses = append(responses, &pb.EchoResponse{Content: word})
 	}
 
+	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return &pb.PagedExpandResponse{
 		Responses:     responses,
@@ -162,6 +171,7 @@ func (s *echoServerImpl) PagedExpandLegacyMapped(ctx context.Context, in *pb.Pag
 		}
 	}
 
+	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return &pb.PagedExpandLegacyMappedResponse{
 		Alphabetized:  alphabetized,
@@ -207,6 +217,7 @@ func min(x int32, y int32) int32 {
 }
 
 func (s *echoServerImpl) Wait(ctx context.Context, in *pb.WaitRequest) (*lropb.Operation, error) {
+	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return s.waiter.Wait(in), nil
 }
@@ -217,8 +228,37 @@ func (s *echoServerImpl) Block(ctx context.Context, in *pb.BlockRequest) (*pb.Bl
 	if in.GetError() != nil {
 		return nil, status.ErrorProto(in.GetError())
 	}
+	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return in.GetSuccess(), nil
+}
+
+//echo any provided headers in the metadata
+func echoHeaders(ctx context.Context) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return
+	}
+
+	values := md.Get("x-goog-request-params")
+	for _, value := range values {
+		header := metadata.Pairs("x-goog-request-params", value)
+		grpc.SetHeader(ctx, header)
+	}
+}
+
+func echoStreamingHeaders(stream grpc.ServerStream) {
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if !ok {
+		return
+	}
+	values := md.Get("x-goog-request-params")
+	for _, value := range values {
+		header := metadata.Pairs("x-goog-request-params", value)
+		if stream.SetHeader(header) != nil {
+			return
+		}
+	}
 }
 
 // echo any provided trailing metadata

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -17,7 +17,6 @@ package services
 import (
 	"context"
 	"io"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -54,10 +53,8 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 
 func (s *echoServerImpl) Expand(in *pb.ExpandRequest, stream pb.Echo_ExpandServer) error {
 	for _, word := range strings.Fields(in.GetContent()) {
-		log.Printf("range_stream: %v:", stream)
 		err := stream.Send(&pb.EchoResponse{Content: word})
 		if err != nil {
-			log.Printf("err_stream: %v:", stream)
 			return err
 		}
 	}
@@ -66,7 +63,6 @@ func (s *echoServerImpl) Expand(in *pb.ExpandRequest, stream pb.Echo_ExpandServe
 		return status.ErrorProto(in.GetError())
 	}
 	echoStreamingTrailers(stream)
-	log.Printf("ending_stream: %v:", stream)
 	return nil
 }
 


### PR DESCRIPTION
As part of supporting dynamic routing annotations per `google/api/routing.proto`, this adds the following:

1) Several sample routing annotations to the `Echo.Echo` method
2) The ability for each `Echo` service to echo the contents set with the `x-goog-request-params` metadata key to the response headers

An example of how to set and read the headers in Go:

```
func main() {
	conn, err := grpc.Dial("localhost:7469", grpc.WithInsecure())
	// This is what the generated client library should be creating
        md := metadata.New(map[string]string{"x-goog-request-params": "testHeader"})
	if err != nil {
		log.Fatal(err)
	}
	defer conn.Close()
	opt := option.WithGRPCConn(conn)
	ctx := metadata.NewOutgoingContext(context.Background(), md)

	echo, err := showcase.NewEchoClient(ctx, opt)
	if err != nil {
		log.Fatal(err)
	}
	defer echo.Close()

	content := "HELLO WORLD"

	req := &showcasepb.EchoRequest{
		Response: &showcasepb.EchoRequest_Content{
			Content: content,
		},
	}
	// Very important step! Another metadata instance must be provided to the `grpc.Header()` with which to capture them.
	mdForHeaders := metadata.New(map[string]string{})

	resp, err := echo.Echo(ctx, req, gax.WithGRPCOptions(grpc.Header(&mdForHeaders)))

	fmt.Printf("This is the response %v\nThis is the header:%v", resp, mdForHeaders.Get("x-goog-request-params")

	if err != nil {
		log.Fatal(err)
	}
}
```

The result should be:
```
This is the response content:"HELLO WORLD"
This is the header:[testHeader]
```

Each language microgenerator can use the following sample tests to the `Echo` method to confirm the dynamic routing annotations are being generated properly.

1) EchoRequest without `header` or `other_header` field specified
Header should be empty.

2) 
```
EchoRequest{
   other_header: “waldo”
}
``` 
Expected Header: `baz=waldo`

3)
```
EchoRequest{
   header: “foo”
}
``` 
Expected Header: `routing_id=foo&header=foo`

4) 
```
EchoRequest{
   header: “projects/foo”
}
``` 
Expected Header: `routing_id=projects/foo&header=projects/foo`

5) 
```
EchoRequest{
   header: “projects/foo/instances/quuz/rows”
}
``` 
Expected Header: `instance_id=instances/quuz&table_name=projects/foo/instances/quuz/rows&header&super_id=projects/foo&routing_id=projects/foo/instances/quuz/rows&header=projects/foo/instances/quuz/rows`

6) 
```
EchoRequest{
   header: “regions/foo/zones/bar/rows””
}
``` 
Expected Header: `table_name=regions/foo/zones/bar/rows&routing_id=regions/foo/zones/bar/rows&header=regions/foo/zones/bar/rows`

7) 
```
EchoRequest{
   header: “projects/foo/instances/bar”
}
``` 
Expected Header: `super_id=projects/foo&routing_id=projects/foo/instances/bar&header=projects/foo/instances/bar`

8) 
```
EchoRequest{
   header: “thud"
   other_header: “projects/foo/instances/bar”
}
``` 
Expected Header: `quz=projects/foo&baz=projects/foo/instances/bar&routing_id=thud&header=thud`