### PR TITLE
chore: add version.go to embed version.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ page, or simply by installing from source using go.
 
 ### Docker
 ```sh
-$ docker pull gcr.io/gapic-images/gapic-showcase:0.19.0
+$ docker pull gcr.io/gapic-images/gapic-showcase:latest
 $ docker run \
     --rm \
     -p 7469:7469/tcp \
     -p 7469:7469/udp \
-    gcr.io/gapic-images/gapic-showcase:0.19.0 \
+    gcr.io/gapic-images/gapic-showcase:latest \
     --help
 > Root command of gapic-showcase
 >
@@ -195,7 +195,7 @@ based on the contents of the Conventional Commits made to the project. Assets
 are then uploaded to the releases that are created.
 
 ## Supported Go Versions
-GAPIC Showcase is supported for go versions 1.11 and later.
+GAPIC Showcase is supported for go versions 1.16 and later.
 
 ## FAQ
 

--- a/cmd/gapic-showcase/version.go
+++ b/cmd/gapic-showcase/version.go
@@ -14,11 +14,17 @@
 
 package main
 
+import (
+	"strings"
+
+	root "github.com/googleapis/gapic-showcase"
+)
+
 func init() {
 	// Make roots version option only emit the version. This is used in Actions.
 	// The template looks weird on purpose. Leaving as a single line causes the
 	// output to append an extra character.
-	rootCmd.Version = "0.19.0"
+	rootCmd.Version = strings.TrimSpace(root.Version)
 	rootCmd.SetVersionTemplate(
 		`{{printf "%s" .Version}}`)
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,10 @@
+package version
+
+import (
+	_ "embed"
+)
+
+// Version contains the current version of this project, as declared in the
+// version.txt file, for its tools to reference.
+//go:embed version.txt
+var Version string

--- a/version.go
+++ b/version.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package version
 
 import (


### PR DESCRIPTION
Also changes gapic-showcase versions in readme to `latest` where possible, and updates the documented min Go version to go1.16 which was already done.