### PR TITLE
chore: Update go command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ gapic-showcase --help
 
 ### Source
 ```sh
-$ go get github.com/googleapis/gapic-showcase/cmd/gapic-showcase
+$ go install github.com/googleapis/gapic-showcase/cmd/gapic-showcase@latest
 $ PATH=$PATH:`go env GOPATH`/bin
 $ gapic-showcase --help
 ...


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead. (https://go.dev/doc/go-get-install-deprecation)