### PR TITLE
chore: remove pin of api-common-protos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "schema/api-common-protos"]
 	path = schema/api-common-protos
 	url = https://github.com/googleapis/api-common-protos.git
-	branch = v0.1.0


### PR DESCRIPTION
The pin is very old, does not seem to serve a visible purpose and it prevents having showcase dependencies e.g. `routing.proto` imported