### PR TITLE
fix: add a routing.proto dependency to showcase proto bazel target

### DIFF
--- a/schema/google/showcase/v1beta1/BUILD.bazel
+++ b/schema/google/showcase/v1beta1/BUILD.bazel
@@ -34,6 +34,7 @@ proto_library(
     "@com_google_googleapis//google/api:client_proto",
     "@com_google_googleapis//google/api:field_behavior_proto",
     "@com_google_googleapis//google/api:resource_proto",
+    "@com_google_googleapis//google/api:routing_proto",
     "@com_google_googleapis//google/longrunning:operations_proto",
     "@com_google_googleapis//google/rpc:status_proto",
     "@com_google_googleapis//google/rpc:error_details_proto",


### PR DESCRIPTION
fixes #1032