### PR TITLE
feat(genrest): format rest errors as Google Errors

### DIFF
--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -289,10 +289,10 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 	file.P("}")
 	file.P("")
 
-	file.P("func (backend *RESTBackend) Error(w http.ResponseWriter, status int, format string, args ...interface{}) {")
+	file.P("func (backend *RESTBackend) Error(w http.ResponseWriter, httpStatus int, format string, args ...interface{}) {")
 	file.P("  message := fmt.Sprintf(format, args...)")
 	file.P("  backend.ErrLog.Print(message)")
-	file.P("  resttools.ErrorResponse(w, status, message)")
+	file.P("  resttools.ErrorResponse(w, httpStatus, message)")
 	file.P("}")
 
 	file.P("func (backend *RESTBackend) ReportGRPCError(w http.ResponseWriter, err error) {")
@@ -303,7 +303,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 	file.P("  }")
 	file.P("")
 	file.P("  backend.ErrLog.Print(st.Message())")
-	file.P("  code := resttools.GRPCToHTTP[st.Code()]")
+	file.P("  code := resttools.GRPCToHTTP(st.Code())")
 	file.P("  resttools.ErrorResponse(w, code, st.Message(), st.Details()...)")
 	file.P("}")
 

--- a/util/genrest/resttools/error_response.go
+++ b/util/genrest/resttools/error_response.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resttools
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+)
+
+// Derived from internal source: go/http-canonical-mapping.
+var GRPCToHTTP map[codes.Code]int = map[codes.Code]int{
+	codes.OK:                 http.StatusOK,
+	codes.Canceled:           499, // There isn't a Go constant ClientClosedConnection
+	codes.Unknown:            http.StatusInternalServerError,
+	codes.InvalidArgument:    http.StatusBadRequest,
+	codes.DeadlineExceeded:   http.StatusGatewayTimeout,
+	codes.NotFound:           http.StatusNotFound,
+	codes.AlreadyExists:      http.StatusConflict,
+	codes.PermissionDenied:   http.StatusForbidden,
+	codes.Unauthenticated:    http.StatusUnauthorized,
+	codes.ResourceExhausted:  http.StatusTooManyRequests,
+	codes.FailedPrecondition: http.StatusBadRequest,
+	codes.Aborted:            http.StatusConflict,
+	codes.OutOfRange:         http.StatusBadRequest,
+	codes.Unimplemented:      http.StatusNotImplemented,
+	codes.Internal:           http.StatusInternalServerError,
+	codes.Unavailable:        http.StatusServiceUnavailable,
+	codes.DataLoss:           http.StatusInternalServerError,
+}
+
+// Google API Errors, as defined by https://cloud.google.com/apis/design/errors
+// will consist of a googleapi.Error nested as the key `error` in a JSON object.
+// So we must create such a structure to wrap our googleapi.Error in.
+type googleAPIError struct {
+	Error *googleapi.Error `json:"error"`
+}
+
+func ErrorResponse(w http.ResponseWriter, status int, message string, details ...interface{}) {
+	googleAPIError := &googleAPIError{
+		Error: &googleapi.Error{
+			Code:    status,
+			Message: message,
+			Details: details,
+		},
+	}
+	w.WriteHeader(status)
+	data, _ := json.Marshal(googleAPIError)
+	w.Write(data)
+}

--- a/util/genrest/resttools/error_response.go
+++ b/util/genrest/resttools/error_response.go
@@ -22,8 +22,9 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// Derived from internal source: go/http-canonical-mapping.
-var GRPCToHTTP map[codes.Code]int = map[codes.Code]int{
+// gRPCToHTTP status code mapping derived from internal source:
+// go/http-canonical-mapping.
+var gRPCToHTTP map[codes.Code]int = map[codes.Code]int{
 	codes.OK:                 http.StatusOK,
 	codes.Canceled:           499, // There isn't a Go constant ClientClosedConnection
 	codes.Unknown:            http.StatusInternalServerError,
@@ -50,6 +51,20 @@ type googleAPIError struct {
 	Error *googleapi.Error `json:"error"`
 }
 
+// GRPCToHTTP maps the given gRPC Code to the canonical HTTP Status code as
+// defined by the internal source go/http-canonical-mapping.
+func GRPCToHTTP(c codes.Code) int {
+	httpStatus, ok := gRPCToHTTP[c]
+	if !ok {
+		httpStatus = http.StatusInternalServerError
+	}
+
+	return httpStatus
+}
+
+// ErrorResponse is a helper that formats the given response information,
+// including the HTTP Status code, a message, and any error detail types, into
+// a googleAPIError and writes the response as JSON.
 func ErrorResponse(w http.ResponseWriter, status int, message string, details ...interface{}) {
 	googleAPIError := &googleAPIError{
 		Error: &googleapi.Error{

--- a/util/genrest/resttools/error_response_test.go
+++ b/util/genrest/resttools/error_response_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resttools
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/googleapi"
+)
+
+func TestErrorResponse(t *testing.T) {
+	for _, tst := range []struct {
+		details       []interface{}
+		message, name string
+		status        int
+	}{
+		{
+			name:    "internal_server",
+			message: "Had an issue",
+			status:  http.StatusInternalServerError,
+		},
+		{
+			name:    "bad_request",
+			message: "The request was bad",
+			status:  http.StatusBadRequest,
+		},
+	} {
+		got := httptest.NewRecorder()
+		ErrorResponse(got, tst.status, tst.message, tst.details...)
+		if got.Code != tst.status {
+			t.Errorf("%s: Expected %d, but got %d", tst.name, tst.status, got.Code)
+		}
+		err := googleapi.CheckResponse(got.Result())
+		var gerr *googleapi.Error
+		if !errors.As(err, &gerr) {
+			t.Fatalf("%s: Expected response to be a googleapi.Error, but got %v", tst.name, err)
+		}
+		if diff := cmp.Diff(gerr.Message, tst.message); diff != "" {
+			t.Errorf("%s: got(-),want(+):%s\n", tst.name, diff)
+		}
+		if diff := cmp.Diff(gerr.Details, tst.details); diff != "" {
+			t.Errorf("%s: got(-),want(+):%s\n", tst.name, diff)
+		}
+	}
+}


### PR DESCRIPTION
This modifies the REST server generator to wrap errors in accordance with [Google Cloud's API Error format](https://cloud.google.com/apis/design/errors). Furthermore, it unpacks the gRPC status-based errors returned by the gRPC server handlers, and converts the gRPC Code into the proper HTTP status code.

Tested locally via Go generator REGAPIC integration tests.