### PR TITLE
fix: remove broken test cases in compliance

### DIFF
--- a/server/services/compliance_suite.json
+++ b/server/services/compliance_suite.json
@@ -145,7 +145,7 @@
     },
     {
       "name": "Fully working conversions, resources",
-      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery", "Compliance.RepeatDataSimplePath", "Compliance.RepeatDataPathResource", "Compliance.RepeatDataPathTrailingResource"],
+      "rpcs": ["Compliance.RepeatDataBody", "Compliance.RepeatDataBodyPut", "Compliance.RepeatDataBodyPatch", "Compliance.RepeatDataQuery"],
       "requests": [
         {
           "name": "Strings with slashes and values that resemble subsequent resource templates",


### PR DESCRIPTION
Removing RPCs that should not be able to transcode the request given in the test suite.
The test gives the following value for the `info.fString` field: `"first/hello/second/greetings"`.

In their respective single http binding uri templates:
- `RepeatDataSimplePath` RPC has a binding `{info.f_string}` which is a shorthand for `{info.f_string=*}`, the pattern `*` does not allow slashes and will not match the value.
- `RepeatDataPathResource` and RepeatDataPathTrailingResource RPCs have the same binding `{info.f_string=first/*}` which does not allow more slashes after the `first/` part and will not match the value.