### PR TITLE
chore(ci): use github api for labeling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,8 +203,16 @@ jobs:
         title: 'chore: regenerate sources'
         message: 'chore: regenerate sources'
         primary: 'main'
-        labels: |
-          automerge
         branch: regen
         git_dir: '.'
         force: true
+    - name: Add automerge label to pull request
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: ${{ steps.code_suggester.outputs.pull }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['automerge']
+          })


### PR DESCRIPTION
`yoshi-code-bot` can't label its own PRs (e.g. with `automerge`), but we can use a follow up step using the GitHub action token to add the label. This is done in gapic-generator-go.