### PR TITLE
fix!: use resource field in http body for Updates

### DIFF
--- a/schema/google/showcase/v1beta1/identity.proto
+++ b/schema/google/showcase/v1beta1/identity.proto
@@ -58,7 +58,7 @@ service Identity {
   rpc UpdateUser(UpdateUserRequest) returns (User) {
     option (google.api.http) = {
       patch: "/v1beta1/{user.name=users/*}"
-      body: "*"
+      body: "user"
     };
   }
 

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -61,7 +61,7 @@ service Messaging {
   rpc UpdateRoom(UpdateRoomRequest) returns (Room) {
     option (google.api.http) = {
       patch: "/v1beta1/{room.name=rooms/*}"
-      body: "*"
+      body: "room"
     };
   }
 
@@ -109,10 +109,10 @@ service Messaging {
   rpc UpdateBlurb(UpdateBlurbRequest) returns (Blurb) {
     option (google.api.http) = {
       patch: "/v1beta1/{blurb.name=rooms/*/blurbs/*}"
-      body: "*"
+      body: "blurb"
       additional_bindings: {
         patch: "/v1beta1/{blurb.name=users/*/profile/blurbs/*}"
-        body: "*"
+        body: "blurb"
       }
     };
   }

--- a/util/genrest/gomodelcreator.go
+++ b/util/genrest/gomodelcreator.go
@@ -77,7 +77,7 @@ func NewGoModel(protoModel *protomodel.Model) (*gomodel.Model, error) {
 				if bodyFieldDesc == nil {
 					goModel.AccumulateError(fmt.Errorf("could not find body field %q in %q", binding.BodyField, inProtoType.GetName()))
 				}
-				bodyFieldTypeDesc, ok := protoInfo.Type[*bodyFieldDesc.TypeName]
+				bodyFieldTypeDesc, ok := protoInfo.Type[bodyFieldDesc.GetTypeName()]
 				if !ok {
 					goModel.AccumulateError(fmt.Errorf("could not read protoInfo[%q]", inProtoType))
 				}

--- a/util/genrest/resttools/populatefield.go
+++ b/util/genrest/resttools/populatefield.go
@@ -243,7 +243,10 @@ func findProtoFieldByJSONName(fieldName string, fields protoreflect.FieldDescrip
 }
 
 func parseWellKnownType(message protoreflect.Message, fieldDescriptor protoreflect.FieldDescriptor, value string) (*protoreflect.Value, error) {
-	messageFieldTypes := message.Type().(protoreflect.MessageFieldTypes)
+	messageFieldTypes, ok := message.Type().(protoreflect.MessageFieldTypes)
+	if !ok {
+		return nil, fmt.Errorf("expected message to implement protoreflect.MessageFieldTypes but it did not")
+	}
 	fieldMsg := messageFieldTypes.Message(fieldDescriptor.Index())
 	fullName := string(fieldMsg.Descriptor().FullName())
 	if !wellKnownTypes[fullName] {


### PR DESCRIPTION
Fixes the `google.api.http` `body` fields for UpdateUser, UpdateBlurb, and UpdateRoom to use the field in the request representing the resource, instead of `*`.

This also adds support for parsing some of the well known protobuf types that may be present as JSON encoded query parameters and that have special JSON encoding formats (see https://developers.google.com/protocol-buffers/docs/proto3#json). This API only makes use of Timestamp, Duration, and FieldMask.