### PR TITLE
fix: build assets for darwin/arm64

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -47,6 +47,8 @@ jobs:
             arch: arm
           - os: darwin
             arch: amd64
+          - os: darwin
+            arch: arm64
           - os: windows
             arch: amd64
     steps:


### PR DESCRIPTION
Fixes #1260 