### PR TITLE
chore: omit gapic snippetgen

### DIFF
--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -62,6 +62,7 @@ func CompileProtos(version string) {
 		"--go_cli_opt=gapic=github.com/googleapis/gapic-showcase/client",
 		"--go_cli_opt=fmt=false",
 		"--go_gapic_out=" + outDir,
+		"--go_gapic_opt=omit-snippets",
 		"--go_gapic_opt=go-gapic-package=github.com/googleapis/gapic-showcase/client;client",
 		"--go_gapic_opt=grpc-service-config=schema/google/showcase/v1beta1/showcase_grpc_service_config.json",
 		"--go_gapic_opt=api-service-config=schema/google/showcase/v1beta1/showcase_v1beta1.yaml",


### PR DESCRIPTION
Don't need the GAPIC snippets generated for showcase, so let's omit them.