### PR TITLE
fix(rest): properly handle string-encoded well-known types in URLs

### DIFF
--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -75,7 +75,7 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 
 			source.P("")
 			source.P("// %s translates REST requests/responses on the wire to internal proto messages for %s", handlerName, handler.GoMethod)
-			source.P("//    Generated for HTTP binding pattern: %q", handler.URIPattern)
+			source.P("//    Generated for HTTP binding pattern: %s %q", handler.HTTPMethod, handler.URIPattern)
 			source.P("func (backend *RESTBackend) %s(w http.ResponseWriter, r *http.Request) {", handlerName)
 			if handler.StreamingClient {
 				source.P(`  backend.Error(w, http.StatusNotImplemented, "client-streaming methods not implemented yet (request matched '%s': %%q)", r.URL)`, handler.URIPattern)

--- a/util/genrest/resttools/headers.go
+++ b/util/genrest/resttools/headers.go
@@ -56,7 +56,8 @@ func CheckContentType(header http.Header) error {
 func CheckAPIClientHeader(header http.Header) error {
 	content, ok := header[headerNameAPIClient]
 	if !ok || len(content) != 1 {
-		return fmt.Errorf("(HeaderAPIClientError) did not find expected HTTP header %q: %q", headerNameAPIClient, headerValueTransportRESTPrefix)
+		return fmt.Errorf("(HeaderAPIClientError) did not find expected HTTP header %q: %q\n                found: %q",
+			headerNameAPIClient, headerValueTransportRESTPrefix, header)
 	}
 
 	var haveREST, haveGAPIC bool

--- a/util/genrest/resttools/populatefield.go
+++ b/util/genrest/resttools/populatefield.go
@@ -268,7 +268,7 @@ func parseWellKnownType(message protoreflect.Message, fieldDescriptor protorefle
 	}
 
 	if stringEncoded {
-		value = fmt.Sprintf(`"%s"`, value)
+		value = fmt.Sprintf("%q", value)
 	}
 
 	msgValue := fieldMsg.New()

--- a/util/genrest/resttools/populatefield_test.go
+++ b/util/genrest/resttools/populatefield_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	genprotopb "github.com/googleapis/gapic-showcase/server/genproto"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -37,52 +36,6 @@ func TestParseWellKnownType(t *testing.T) {
 		name  string
 		msg   protoreflect.Message
 		field protoreflect.Name
-		want  proto.Message
-	}{
-		{
-			"google.protobuf.FieldMask",
-			(&genprotopb.UpdateUserRequest{}).ProtoReflect(),
-			"update_mask",
-			&fieldmaskpb.FieldMask{Paths: []string{"foo", "bar", "baz"}},
-		},
-		{
-			"google.protobuf.Timestamp",
-			(&genprotopb.User{}).ProtoReflect(),
-			"create_time",
-			timestamppb.Now(),
-		},
-		{
-			"google.protobuf.Duration",
-			(&genprotopb.Sequence_Response{}).ProtoReflect(),
-			"delay",
-			durationpb.New(5 * time.Second),
-		},
-	} {
-		data, _ := protojson.Marshal(tst.want)
-		value := string(data)
-		fd := tst.msg.Descriptor().Fields().ByName(tst.field)
-
-		gotp, err := parseWellKnownType(tst.msg, fd, value)
-		if err != nil {
-			t.Fatalf("parsing %q led to error %s", value, err)
-		}
-		if gotp == nil {
-			t.Fatalf("expected non-nil value from parsing: %s", value)
-		}
-		got := gotp.Message().Interface()
-		if diff := cmp.Diff(got, tst.want, cmp.Comparer(proto.Equal)); diff != "" {
-			t.Fatalf("%s: got(-),want(+):\n%s", "FieldMask", diff)
-		}
-	}
-}
-
-func TestParseWellKnownTypeUnquoted(t *testing.T) {
-	// TODO: Test the other well-known types as the Showcase API
-	// starts incorporating them.
-	for _, tst := range []struct {
-		name  string
-		msg   protoreflect.Message
-		field protoreflect.Name
 		value string
 		want  proto.Message
 	}{
@@ -90,7 +43,7 @@ func TestParseWellKnownTypeUnquoted(t *testing.T) {
 			"google.protobuf.FieldMask",
 			(&genprotopb.UpdateUserRequest{}).ProtoReflect(),
 			"update_mask",
-			`foo,bar,baz`,
+			"foo,bar,baz",
 			&fieldmaskpb.FieldMask{Paths: []string{"foo", "bar", "baz"}},
 		},
 


### PR DESCRIPTION
Well-known type messages that JSON-encode to strings appear in URL paths and query params unquoted. When we extract them from these places, we need to quote them to make them valid JSON that we can pass to the JSON deserializer. We weren't doing the quoting previously.

Fixes #1263 