### PR TITLE
chore(genrest): fix casing for body field

### DIFF
--- a/util/genrest/gomodelcreator.go
+++ b/util/genrest/gomodelcreator.go
@@ -16,12 +16,12 @@ package genrest
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-showcase/util/genrest/gomodel"
 	"github.com/googleapis/gapic-showcase/util/genrest/internal/pbinfo"
 	"github.com/googleapis/gapic-showcase/util/genrest/protomodel"
+	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -84,7 +84,7 @@ func NewGoModel(protoModel *protomodel.Model) (*gomodel.Model, error) {
 				requestBodyFieldType, bodyFieldImports, err = protoInfo.NameSpec(bodyFieldTypeDesc)
 				// TODO: test for HTTP body encoding a single field whose names is different than its type
 				// TODO: Test for HTTP body encoding a single field that is a scalar, not a message
-				requestBodyFieldName = strings.Title(bodyFieldDesc.GetName())
+				requestBodyFieldName = strcase.ToCamel(bodyFieldDesc.GetName())
 				goModel.AccumulateError(err)
 			}
 


### PR DESCRIPTION
Request body fields that are `snake_case` were not being `CamelCase`'d properly as `strings.Title` does not convert `snake_case` to `CamelCase`, it just sets the first letter in each word to uppercase, but without splitting on `_` first.

Tested with changes in #1266 .

Blocking #1266