### PR TITLE
fix: remove content_sent from StreamingSequences

### DIFF
--- a/schema/google/showcase/v1beta1/sequence.proto
+++ b/schema/google/showcase/v1beta1/sequence.proto
@@ -166,7 +166,6 @@ message StreamingSequenceReport {
     // The status returned to the attempt.
     google.rpc.Status status = 5;
 
-    string content_sent = 6;
   }
 
   // The set of RPC attempts received by the server for a Sequence.

--- a/server/services/sequence_service.go
+++ b/server/services/sequence_service.go
@@ -283,7 +283,6 @@ func (s *sequenceServerImpl) AttemptStreamingSequence(in *pb.AttemptStreamingSeq
 		Status:        st.Proto(),
 	})
 
-
 	return st.Err()
 
 }


### PR DESCRIPTION
Currently, server streaming APIs do not resume from the point of failure. Before removing the contentSent property, the server would keep track of the last content that was sent before failing. To get closure to how server streams currently react to failure, we removed the contentSent property. This means that when we retry the request, the server will send the entire content, rather than starting from where it left off.