### PR TITLE
feat: add EchoErrorDetails RPC returning error.details as field type google.protobuf.Any 

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -87,7 +87,7 @@ service Echo {
   // This method returns error details in a repeated "google.protobuf.Any"
   // field. This method showcases handling errors thus encoded, particularly
   // over REST transport. Note that GAPICs only allow the type
-  // "google.protobuf.Any" for field paths ending in "error.details", and at
+  // "google.protobuf.Any" for field paths ending in "error.details", and, at
   // run-time, the actual types for these fields must be one of the types in
   // google/rpc/error_details.proto.
   rpc EchoErrorDetails(EchoErrorDetailsRequest) returns (EchoErrorDetailsResponse) {
@@ -100,7 +100,7 @@ service Echo {
   // This method returns error details in a singular "google.protobuf.Any"
   // field. This method showcases handling errors thus encoded, particularly
   // over REST transport. Note that GAPICs only allow the type
-  // "google.protobuf.Any" for field paths ending in "error.details", and at
+  // "google.protobuf.Any" for field paths ending in "error.details", and, at
   // run-time, the actual types for these fields must be one of the types in
   // google/rpc/error_details.proto.
   rpc EchoErrorSingleDetail(EchoErrorSingleDetailRequest) returns (EchoErrorSingleDetailResponse) {

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -237,14 +237,19 @@ message EchoResponse {
 message EchoErrorDetailsRequest {
   repeated string text = 1;
   string single_detail_text = 2;
+  repeated string multi_detail_text = 3;
 }
 // The response message used for the EchoErrorDetails method.
 message EchoErrorDetailsResponse {
   message SingleDetail {
     ErrorWithSingleDetail error = 1;
   }
+  message MultipleDetails {
+    ErrorWithMultipleDetails error = 1;    
+  }
   ErrorWithMultipleDetails error = 1;
   SingleDetail single_detail = 2;
+  MultipleDetails multiple_details = 3;
 }
 
 message ErrorWithMultipleDetails {

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -97,19 +97,6 @@ service Echo {
     };
   }
 
-  // This method returns error details in a singular "google.protobuf.Any"
-  // field. This method showcases handling errors thus encoded, particularly
-  // over REST transport. Note that GAPICs only allow the type
-  // "google.protobuf.Any" for field paths ending in "error.details", and, at
-  // run-time, the actual types for these fields must be one of the types in
-  // google/rpc/error_details.proto.
-  rpc EchoErrorSingleDetail(EchoErrorSingleDetailRequest) returns (EchoErrorSingleDetailResponse) {
-    option (google.api.http) = {
-      post: "/v1beta1/echo:error-single-detail"
-      body: "*"
-    };
-  }
-
   // This method splits the given content into words and will pass each word back
   // through the stream. This method showcases server-side streaming RPCs.
   rpc Expand(ExpandRequest) returns (stream EchoResponse) {
@@ -235,41 +222,36 @@ message EchoResponse {
 
 // The request message used for the EchoErrorDetails method.
 message EchoErrorDetailsRequest {
-  repeated string text = 1;
-  string single_detail_text = 2;
-  repeated string multi_detail_text = 3;
+  // Content to return in a singular `*.error.details` field of type
+  // `google.protobuf.Any`
+  string single_detail_text = 1;
+
+  // Content to return in a repeated `*.error.details` field of type
+  // `google.protobuf.Any`
+  repeated string multi_detail_text = 2;
 }
+
 // The response message used for the EchoErrorDetails method.
 message EchoErrorDetailsResponse {
+
   message SingleDetail {
     ErrorWithSingleDetail error = 1;
   }
+
   message MultipleDetails {
-    ErrorWithMultipleDetails error = 1;    
+    ErrorWithMultipleDetails error = 1;
   }
-  ErrorWithMultipleDetails error = 1;
-  SingleDetail single_detail = 2;
-  MultipleDetails multiple_details = 3;
-}
 
-message ErrorWithMultipleDetails {
-  repeated google.protobuf.Any details=1;
-}
-
-// *** DELETE
-// The request message used for the EchoErrorSingleDetail method.
-message EchoErrorSingleDetailRequest { 
-  string text = 1;
-}
-
-// *** DELETE
-// The response message used for the EchoErrorSingleDetail method.
-message EchoErrorSingleDetailResponse {
-  ErrorWithSingleDetail error = 1;
+  SingleDetail single_detail = 1;
+  MultipleDetails multiple_details = 2;
 }
 
 message ErrorWithSingleDetail {
-  google.protobuf.Any details=1;
+  google.protobuf.Any details = 1;
+}
+
+message ErrorWithMultipleDetails {
+  repeated google.protobuf.Any details = 1;
 }
 
 // The request message for the Expand method.

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -235,22 +235,29 @@ message EchoResponse {
 
 // The request message used for the EchoErrorDetails method.
 message EchoErrorDetailsRequest {
-  repeated string text = 2;
+  repeated string text = 1;
+  string single_detail_text = 2;
 }
 // The response message used for the EchoErrorDetails method.
 message EchoErrorDetailsResponse {
+  message SingleDetail {
+    ErrorWithSingleDetail error = 1;
+  }
   ErrorWithMultipleDetails error = 1;
+  SingleDetail single_detail = 2;
 }
 
 message ErrorWithMultipleDetails {
   repeated google.protobuf.Any details=1;
 }
 
+// *** DELETE
 // The request message used for the EchoErrorSingleDetail method.
-message EchoErrorSingleDetailRequest {
+message EchoErrorSingleDetailRequest { 
   string text = 1;
 }
 
+// *** DELETE
 // The response message used for the EchoErrorSingleDetail method.
 message EchoErrorSingleDetailResponse {
   ErrorWithSingleDetail error = 1;

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -19,6 +19,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/routing.proto";
 import "google/longrunning/operations.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
@@ -34,7 +35,7 @@ option ruby_package = "Google::Showcase::V1beta1";
 // side streaming, client side streaming, and bidirectional streaming. This
 // service also exposes methods that explicitly implement server delay, and
 // paginated calls. Set the 'showcase-trailer' metadata key on any method
-// to have the values echoed in the response trailers. Set the 
+// to have the values echoed in the response trailers. Set the
 // 'x-goog-request-params' metadata key on any method to have the values
 // echoed in the response headers.
 service Echo {
@@ -80,6 +81,32 @@ service Echo {
         field: "other_header"
         path_template: "{qux=projects/*}/**"
       }
+    };
+  }
+
+  // This method returns error details in a repeated "google.protobuf.Any"
+  // field. This method showcases handling errors thus encoded, particularly
+  // over REST transport. Note that GAPICs only allow the type
+  // "google.protobuf.Any" for field paths ending in "error.details", and at
+  // run-time, the actual types for these fields must be one of the types in
+  // google/rpc/error_details.proto.
+  rpc EchoErrorDetails(EchoErrorDetailsRequest) returns (EchoErrorDetailsResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:error-details"
+      body: "*"
+    };
+  }
+
+  // This method returns error details in a singular "google.protobuf.Any"
+  // field. This method showcases handling errors thus encoded, particularly
+  // over REST transport. Note that GAPICs only allow the type
+  // "google.protobuf.Any" for field paths ending in "error.details", and at
+  // run-time, the actual types for these fields must be one of the types in
+  // google/rpc/error_details.proto.
+  rpc EchoErrorSingleDetail(EchoErrorSingleDetailRequest) returns (EchoErrorSingleDetailResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:error-single-detail"
+      body: "*"
     };
   }
 
@@ -204,6 +231,33 @@ message EchoResponse {
 
   // The severity specified in the request.
   Severity severity = 2;
+}
+
+// The request message used for the EchoErrorDetails method.
+message EchoErrorDetailsRequest {
+  repeated string text = 2;
+}
+// The response message used for the EchoErrorDetails method.
+message EchoErrorDetailsResponse {
+  ErrorWithMultipleDetails error = 1;
+}
+
+message ErrorWithMultipleDetails {
+  repeated google.protobuf.Any details=1;
+}
+
+// The request message used for the EchoErrorSingleDetail method.
+message EchoErrorSingleDetailRequest {
+  string text = 1;
+}
+
+// The response message used for the EchoErrorSingleDetail method.
+message EchoErrorSingleDetailResponse {
+  ErrorWithSingleDetail error = 1;
+}
+
+message ErrorWithSingleDetail {
+  google.protobuf.Any details=1;
 }
 
 // The request message for the Expand method.

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -60,7 +60,7 @@ func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorD
 		errorInfo := &errdetails.ErrorInfo{
 			Reason: text,
 		}
-		marshalledError, err := ptypes.MarshalAny(errorInfo)
+		marshalledError, err := anypb.New(errorInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failure in EchoErrorDetails[%d]: %w", idx, err)
 		}
@@ -81,7 +81,7 @@ func (s *echoServerImpl) EchoErrorSingleDetail(ctx context.Context, in *pb.EchoE
 	errorInfo := &errdetails.ErrorInfo{
 		Reason: in.GetText(),
 	}
-	marshalledError, err := ptypes.MarshalAny(errorInfo)
+	marshalledError, err := anypb.New(errorInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failure in EchoErrorSingleDetail: %w", err)
 	}

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -55,8 +55,8 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 }
 
 func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorDetailsRequest) (*pb.EchoErrorDetailsResponse, error) {
-	var errorWithMultipleDetails *pb.ErrorWithMultipleDetails
-	multipleDetailText := in.GetText()
+	var multipleDetailsError *pb.EchoErrorDetailsResponse_MultipleDetails
+	multipleDetailText := in.GetMultiDetailText()
 	if len(multipleDetailText) > 0 {
 		details := []*anypb.Any{}
 		for idx, text := range multipleDetailText {
@@ -71,8 +71,8 @@ func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorD
 			details = append(details, marshalledError)
 		}
 
-		errorWithMultipleDetails = &pb.ErrorWithMultipleDetails{
-			Details: details,
+		multipleDetailsError = &pb.EchoErrorDetailsResponse_MultipleDetails{
+			Error: &pb.ErrorWithMultipleDetails{Details: details},
 		}
 	}
 
@@ -92,8 +92,8 @@ func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorD
 	echoHeaders(ctx)
 	echoTrailers(ctx)
 	return &pb.EchoErrorDetailsResponse{
-		Error:        errorWithMultipleDetails,
-		SingleDetail: singleDetailError,
+		MultipleDetails: multipleDetailsError,
+		SingleDetail:    singleDetailError,
 	}, nil
 }
 

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -411,11 +411,7 @@ func TestEchoErrorDetails(t *testing.T) {
 		{
 			[]string{"rain", "snow", "hail", "sleet", "fog"},
 			[]*errdetails.ErrorInfo{
-				{
-					Reason:   "rain",
-					Domain:   "",
-					Metadata: map[string]string{},
-				},
+				{Reason: "rain"},
 				{Reason: "snow"},
 				{Reason: "hail"},
 				{Reason: "sleet"},

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -423,30 +423,34 @@ func TestEchoErrorDetails(t *testing.T) {
 
 	server := NewEchoServer()
 	for idx, test := range tests {
-		request := &pb.EchoErrorDetailsRequest{Text: test.text}
+		request := &pb.EchoErrorDetailsRequest{MultiDetailText: test.text}
 		out, err := server.EchoErrorDetails(context.Background(), request)
 		if err != nil {
 			t.Errorf("[%d] error calling EchoErrorSingleDetail(): %v", idx, err)
 			continue
 		}
 		if len(test.text) == 0 {
-			if out.Error != nil {
-				t.Errorf("[%d] expected no Error, but got %#v", idx, out.Error)
+			if out.MultipleDetails != nil {
+				t.Errorf("[%d] expected no MultipleDetails, but got %#v", idx, out.Error)
 			}
 			continue
 		}
-		if out.Error == nil {
-			t.Errorf("[%d] no Error returned", idx)
+		if out.MultipleDetails == nil {
+			t.Errorf("[%d] no MultipleDetails returned", idx)
 			continue
 		}
-		if out.Error.Details == nil {
-			t.Errorf("[%d] no Error.Details returned", idx)
+		if out.MultipleDetails.Error == nil {
+			t.Errorf("[%d] no MultipleDetails.Error returned", idx)
 			continue
 		}
-		if got, want := len(out.Error.Details), len(test.expected); got != want {
-			t.Errorf("[%d] expected %d Error.Details, got %d", idx, want, got)
+		if out.MultipleDetails.Error.Details == nil {
+			t.Errorf("[%d] no MultipleDetails.Error.Details returned", idx)
+			continue
 		}
-		for whichDetail, detail := range out.Error.Details {
+		if got, want := len(out.MultipleDetails.Error.Details), len(test.expected); got != want {
+			t.Errorf("[%d] expected %d MultipleDetails.Error.Details, got %d", idx, want, got)
+		}
+		for whichDetail, detail := range out.MultipleDetails.Error.Details {
 			if got, want := detail.TypeUrl, "type.googleapis.com/google.rpc.ErrorInfo"; got != want {
 				t.Errorf("[%d:%d] expected type URL %q; got %q ", idx, whichDetail, want, got)
 			}


### PR DESCRIPTION
In the DIREGAPIC flow (`rest`-transport clients generated from synthetic protos emitted by  https://github.com/googleapis/disco-to-proto3-converter from public Discovery documents) currently used for the Google Compute Engine GAPIC, we only allow `google.protobuf.Any` types for fields whose paths end in `.error.details`. The actual types at run-time must be one of the types in `google/rpc/error_details.proto`. Since `error_details.proto` is not explicitly included in the synthetic GCE protos or the Showcase protos, we want to ensure that GAPICs in all languages can successfully decode these `error_details.proto` messages in a language-appropriate manner.

This change implements an RPC `EchoErrorDetails()` that adds such an `Any`-type field to the schema and return such an allowed `error_details.proto` actual value from the server. This can be used to verify that generated GAPICs can indeed process `Any` fields whose actual types are those in `error_details.proto`.

The new server functionality can be tested from the command line via the following:

```
curl -i -X POST http://localhost:7469/v1beta1/echo:error-details \
   -d'{"singleDetailText": "Rain","multiDetailText":["rain", "snow" , "hail", "sleet", "fog"]}' \
   -H "Content-Type: application/json" -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0"     
curl -i -X POST http://localhost:7469/v1beta1/echo:error-details \
   -d'{"singleDetailText": "Rain"}' \
   -H "Content-Type: application/json" -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0"     
curl -i -X POST http://localhost:7469/v1beta1/echo:error-details \
   -d'{"multiDetailText":["rain", "snow" , "hail", "sleet", "fog"]}' -H "Content-Type: application/json" \
   -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0"     

```

(This change is motivated by https://github.com/googleapis/disco-to-proto3-converter/pull/102, which adds support for `Any` fields only in `....error.details`.)