### PR TITLE
feat: replace api-common-protos submodule with googleapis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.19.2'
-        repo-token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
     - name: Install external generators

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
         go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@latest
     - uses: actions/checkout@v3
     - name: Checkout common protos
+      with:
+        repo-token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       run: git submodule init && git submodule update
     - name: Download go deps
       run: go mod download

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.19.2'
+        repo-token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
     - name: Install external generators
@@ -24,8 +25,6 @@ jobs:
         go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic@latest
     - uses: actions/checkout@v3
     - name: Checkout common protos
-      with:
-        repo-token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       run: git submodule init && git submodule update
     - name: Download go deps
       run: go mod download

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googleapis"]
 	path = schema/googleapis
-	url = git@github.com:googleapis/googleapis.git
+	url = https://yoshi-code-bot:${{ secrets.YOSHI_CODE_BOT_TOKEN }}@github.com/googleapis/googleapis.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googleapis"]
 	path = schema/googleapis
-	url = https://yoshi-code-bot:${{ secrets.YOSHI_CODE_BOT_TOKEN }}@github.com/googleapis/googleapis.git
+	url = https://github.com/googleapis/googleapis.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googleapis"]
-	path = googleapis
+	path = schema/googleapis
 	url = git@github.com:googleapis/googleapis.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "schema/api-common-protos"]
-	path = schema/api-common-protos
-	url = https://github.com/googleapis/api-common-protos.git
+[submodule "googleapis"]
+	path = googleapis
+	url = git@github.com:googleapis/googleapis.git

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ hold using this installation method._
 
 ## Schema
 The schema of GAPIC Showcase API can be found in [schema/google/showcase/v1beta1](schema/google/showcase/v1beta1)
-Its dependencies can be found in the [googleapis/api-common-protos](https://github.com/googleapis/api-common-protos)
+Its dependencies can be found in the [googleapis/googleapis](https://github.com/googleapis/googleapis)
 submodule.
 
 ## Development Environment
@@ -80,7 +80,7 @@ To set up this repository for local development, follow these steps:
 or your OS package manager. This API utilizes `proto3_optional`, thus `v3.12.0`
 is the minimum supported version of `protoc`.
 
-1. Initialize the `api-common-protos` submodule:
+1. Initialize the `googleapis` submodule:
     ```sh
     git submodule update --init --recursive
     ```

--- a/util/cmd/release/main.go
+++ b/util/cmd/release/main.go
@@ -65,7 +65,7 @@ func main() {
 	// Move schema files alongside their dependencies.
 	util.Execute("cp", "-rf", filepath.Join("schema", "google"), tmpProtoPath)
 
-	apiPath := filepath.Join("schema", "api-common-protos", "google", "api")
+	apiPath := filepath.Join("schema", "googleapis", "google", "api")
 	tmpAPIPath := filepath.Join(tmpProtoPath, "google", "api")
 	os.MkdirAll(tmpAPIPath, 0755)
 	util.Execute("cp", filepath.Join(apiPath, "annotations.proto"), tmpAPIPath)
@@ -75,12 +75,12 @@ func main() {
 	util.Execute("cp", filepath.Join(apiPath, "resource.proto"), tmpAPIPath)
 	util.Execute("cp", filepath.Join(apiPath, "routing.proto"), tmpAPIPath)
 
-	longrunningPath := filepath.Join("schema", "api-common-protos", "google", "longrunning")
+	longrunningPath := filepath.Join("schema", "googleapis", "google", "longrunning")
 	tmpLongrunningPath := filepath.Join(tmpProtoPath, "google", "longrunning")
 	os.MkdirAll(tmpLongrunningPath, 0755)
 	util.Execute("cp", filepath.Join(longrunningPath, "operations.proto"), tmpLongrunningPath)
 
-	rpcPath := filepath.Join("schema", "api-common-protos", "google", "rpc")
+	rpcPath := filepath.Join("schema", "googleapis", "google", "rpc")
 	tmpRPCPath := filepath.Join(tmpProtoPath, "google", "rpc")
 	os.MkdirAll(tmpRPCPath, 0755)
 	util.Execute("cp", filepath.Join(rpcPath, "status.proto"), tmpRPCPath)

--- a/util/compile_protos.go
+++ b/util/compile_protos.go
@@ -55,7 +55,7 @@ func CompileProtos(version string) {
 	command := []string{
 		"protoc",
 		"--experimental_allow_proto3_optional",
-		"--proto_path=schema/api-common-protos",
+		"--proto_path=schema/googleapis",
 		"--proto_path=schema",
 		"--go_cli_out=" + filepath.Join("cmd", "gapic-showcase"),
 		"--go_cli_opt=root=gapic-showcase",


### PR DESCRIPTION
https://github.com/googleapis/api-common-protos needs to be manually updated, so there is a 2-step process for `gapic-showcase` to pull in updated `api-common-protos`. By replacing the `api-common-protos` submodule with `googleapis`, it removes one of those steps. 