### PR TITLE
feat: add autopopulated request id field to echo

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
 import "google/api/routing.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/any.proto";
@@ -209,6 +210,11 @@ message EchoRequest {
 
   // Optional. This field can be set to test the routing annotation on the Echo method.
   string other_header = 5;
+
+  // Based on go/client-populate-request-id-design; subject to change
+  string request_id = 7 [
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // The response message for the Echo methods.

--- a/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -83,3 +83,8 @@ http:
     delete: '/v1beta1/{name=operations/**}'
   - selector: google.longrunning.Operations.CancelOperation
     post: '/v1beta1/{name=operations/**}:cancel'
+publishing:
+  method_settings:
+  - selector: google.showcase.v1beta1.Echo.Echo
+    auto_populated_fields:
+    - request_id


### PR DESCRIPTION
Creating a new PR in place of https://github.com/googleapis/gapic-showcase/pull/1398/ that just contains the proto / service.yaml updates. 

This shows what the "happy path" configuration should look like for auto-population of the request_id for the Echo method on the Echo service .