### PR TITLE
chore: update release workflow to work on manual trigger

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -4,10 +4,15 @@ on:
   release:
     types:
       - created
-
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to checkout'
+        required: true
+        type: string
 env:
-  # e.g. v1.0.0
-  TAG_NAME: ${{ github.event.release.tag_name }}
+  # e.g. v1.0.0 (use release tag on release events or the provided tag on manual invocation)
+  TAG_NAME: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
 jobs:
   proto-assets:

--- a/util/cmd/release/main.go
+++ b/util/cmd/release/main.go
@@ -68,12 +68,7 @@ func main() {
 	apiPath := filepath.Join("schema", "googleapis", "google", "api")
 	tmpAPIPath := filepath.Join(tmpProtoPath, "google", "api")
 	os.MkdirAll(tmpAPIPath, 0755)
-	util.Execute("cp", filepath.Join(apiPath, "annotations.proto"), tmpAPIPath)
-	util.Execute("cp", filepath.Join(apiPath, "client.proto"), tmpAPIPath)
-	util.Execute("cp", filepath.Join(apiPath, "field_behavior.proto"), tmpAPIPath)
-	util.Execute("cp", filepath.Join(apiPath, "http.proto"), tmpAPIPath)
-	util.Execute("cp", filepath.Join(apiPath, "resource.proto"), tmpAPIPath)
-	util.Execute("cp", filepath.Join(apiPath, "routing.proto"), tmpAPIPath)
+	util.Execute("cp", filepath.Join(apiPath, "*.proto"), tmpAPIPath)
 
 	longrunningPath := filepath.Join("schema", "googleapis", "google", "longrunning")
 	tmpLongrunningPath := filepath.Join(tmpProtoPath, "google", "longrunning")


### PR DESCRIPTION
- Update the release workflow to work on manual invocation in case the automated release process fails
- Updates the release script to copy all files from `googleapis/google/api` so that any new protos added into that directory are automatically pulled in. This creates some extra baggage (e.g. including proto files that aren't strictly needed), but removes the need for manual maintenance when a new proto gets added in that is needed. 