### PR TITLE
chore: fix globbing of wildcard protos in release script

### DIFF
--- a/util/cmd/release/main.go
+++ b/util/cmd/release/main.go
@@ -68,7 +68,13 @@ func main() {
 	apiPath := filepath.Join("schema", "googleapis", "google", "api")
 	tmpAPIPath := filepath.Join(tmpProtoPath, "google", "api")
 	os.MkdirAll(tmpAPIPath, 0755)
-	util.Execute("cp", filepath.Join(apiPath, "*.proto"), tmpAPIPath)
+	protoFiles, err := filepath.Glob(filepath.Join(apiPath, "*.proto"))
+	if err != nil {
+		log.Fatal("Failed to find proto files within googleapis/google/api/*")
+	}
+	for _, protoFile := range protoFiles {
+		util.Execute("cp", protoFile, tmpAPIPath)
+	}
 
 	longrunningPath := filepath.Join("schema", "googleapis", "google", "longrunning")
 	tmpLongrunningPath := filepath.Join(tmpProtoPath, "google", "longrunning")


### PR DESCRIPTION
Follow up to https://github.com/googleapis/gapic-showcase/pull/1415

From https://github.com/googleapis/gapic-showcase/actions/runs/7491564937/job/20393070447 :
```
2024/01/11 16:21:36 cp: cannot stat 'schema/googleapis/google/api/*.proto': No such file or directory
```

shows the copying of the proto files wasn't working correctly as it wasn't recognizing the wildcard. This should hopefully fix that.