### PR TITLE
chore: update assets.yaml for manual invocation

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -22,6 +22,8 @@ jobs:
         with:
           go-version: '1.19.2'
       - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.TAG_NAME }}
       - name: Init submodule
         run: git submodule init && git submodule update
       - name: Set raw version
@@ -37,7 +39,7 @@ jobs:
         with:
           repo_token: ${{ github.token }}
           file: ./dist/*
-          tag: ${{ github.event.release.tag_name }}
+          tag: ${{ env.TAG_NAME }}
           overwrite: true
           file_glob: true
   binary-assets:


### PR DESCRIPTION
...and another follow up to https://github.com/googleapis/gapic-showcase/pull/1416

https://github.com/googleapis/gapic-showcase/actions/runs/7491935131/job/20394310060#step:8:1 shows:

```
Run svenstaro/upload-release-action@v2
  with:
    repo_token: ***
    file: ./dist/*
    overwrite: true
    file_glob: true
  env:
    TAG_NAME: v0.[3](https://github.com/googleapis/gapic-showcase/actions/runs/7491935131/job/20394310060#step:8:3)0.0
Error: Input required and not supplied: tag
```

This updates the workflow to use either the event tag or the manually supplied tag.