### PR TITLE
chore: update workflow to run from main temporarily

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           go-version: '1.19.2'
       - uses: actions/checkout@v4
-        with:
-          ref: refs/tags/${{ env.TAG_NAME }}
       - name: Init submodule
         run: git submodule init && git submodule update
       - name: Set raw version


### PR DESCRIPTION
and another follow up to: https://github.com/googleapis/gapic-showcase/pull/1417

From: https://github.com/googleapis/gapic-showcase/actions/runs/7492920153/job/20397491734#step:7:12

```
Run go run ./util/cmd/release -version=0.30.0
2024/01/11 18:22:15 google/api/launch_stage.proto: File not found.
google/api/client.proto:19:1: Import "google/api/launch_stage.proto" was not found or had errors.
google/api/client.proto:121:3: "LaunchStage" is not defined.
google/showcase/v1beta1/compliance.proto:1[8](https://github.com/googleapis/gapic-showcase/actions/runs/7492920153/job/20397491734#step:7:9):1: Import "google/api/client.proto" was not found or had errors.
exit status 1
Error: Process completed with exit code 1.
```

I think what's happening is that since it's checking out the version of the repo at the tag, that repo does not have the updated `release/main.go` script that copies all the files from `googleapis/google/api` and we get the original error. So this PR removes this step so that we can run the workflow for v0.30.0. 

This step should probably get added back on for future versions to ensure that the manual invocation is creating the assets for the correct version.  However, that means it won't work for any release version before the next released version (that contains the corrected `main.go` script). 