### PR TITLE
chore: Update Github upload_url in workflow

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.release.tag_name }}
     run: echo "GITHUB_UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
   get-upload-url-manual:
-    name: Get upload URL for manually triggered release
+    name: Get upload URL for manually triggered releases
     if: ${{ github.event.inputs.tag }}
     uses: actions/github-script@v7
     id: get-upload-url
@@ -31,7 +31,6 @@ jobs:
           repo: context.repo.repo,
           tag: "${{ github.event.inputs.tag }}"
         });
-    name: set-upload-url
     run: echo "GITHUB_UPLOAD_URL=${{ steps.get-upload-url.outputs.upload_url }}" >> $GITHUB_ENV
   proto-assets:
     runs-on: ubuntu-latest

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -15,6 +15,24 @@ env:
   TAG_NAME: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
 jobs:
+  get-upload-url-release:
+    name: Get upload URL for automated releases
+    if: ${{ github.event.release.tag_name }}
+    run: echo "GITHUB_UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
+  get-upload-url-manual:
+    name: Get upload URL for manually triggered release
+    if: ${{ github.event.inputs.tag }}
+    uses: actions/github-script@v7
+    id: get-upload-url
+    with:
+      script: |
+        github.rest.repos.getReleaseByTag({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          tag: "${{ github.event.inputs.tag }}"
+        });
+    name: set-upload-url
+    run: echo "GITHUB_UPLOAD_URL=${{ steps.get-upload-url.outputs.upload_url }}" >> $GITHUB_ENV
   proto-assets:
     runs-on: ubuntu-latest
     steps:
@@ -84,7 +102,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ env.GITHUB_UPLOAD_URL }}
           asset_path: ./gapic-showcase.tar.gz
           asset_name: gapic-showcase-${{ steps.raw_tag.outputs.raw_version }}-${{ matrix.osarch.os }}-${{ matrix.osarch.arch }}.tar.gz
           asset_content_type: application/tar+gzip


### PR DESCRIPTION
From: https://github.com/googleapis/gapic-showcase/actions/runs/7493151012/job/20398247464

```
Run actions/upload-release-asset@v1
Error: Input required and not supplied: upload_url
```

We need to supply the `upload_url` for manual invocation of the workflow. This attempts to fix that.