### PR TITLE
chore: set github output

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -16,11 +16,15 @@ env:
 
 jobs:
   get-upload-url:
+    outputs:
+      automated_upload_url: ${{ steps.automated-upload-url.outputs.GITHUB_UPLOAD_URL }}
+      manual_upload_url: ${{ steps.get-upload-url.outputs.GITHUB_UPLOAD_URL }}
     runs-on: ubuntu-latest
     steps:
       - name: Get upload URL for automated releases
+        id: automated-upload-url
         if: ${{ github.event.release.tag_name }}
-        run: echo "GITHUB_UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
+        run: echo "GITHUB_UPLOAD_URL=${{ github.event.release.upload_url }}" >> "$GITHUB_OUTPUT"
       - name: Get upload URL for manually triggered releases
         if: ${{ github.event.inputs.tag }}
         id: get-upload-url
@@ -36,7 +40,7 @@ jobs:
             core.setOutput("upload_url", release.data.upload_url);
       - name: Set environment variable
         if: ${{ github.event.inputs.tag }}
-        run: echo "GITHUB_UPLOAD_URL=${{ steps.get-upload-url.outputs.upload_url }}" >> $GITHUB_ENV
+        run: echo "GITHUB_UPLOAD_URL=${{ steps.get-upload-url.outputs.upload_url }}" >> "$GITHUB_OUTPUT"
   proto-assets:
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +68,7 @@ jobs:
           file_glob: true
   binary-assets:
     runs-on: ubuntu-latest
-    needs: proto-assets
+    needs: [get-upload-url, proto-assets]
     strategy:
       matrix:
         osarch:
@@ -105,8 +109,9 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_UPLOAD_URL: ${{ if ne(${{ needs.get-upload-url.outputs.automated_upload_url }}, '') }}${{ needs.get-upload-url.outputs.manual_upload_url }}${{ else }}${{ needs.get-upload-url.outputs.automated_upload_url }}${{ endif }}
         with:
-          upload_url: ${{ env.GITHUB_UPLOAD_URL }}
+          upload_url: ${{ GITHUB_UPLOAD_URL }}
           asset_path: ./gapic-showcase.tar.gz
           asset_name: gapic-showcase-${{ steps.raw_tag.outputs.raw_version }}-${{ matrix.osarch.os }}-${{ matrix.osarch.arch }}.tar.gz
           asset_content_type: application/tar+gzip


### PR DESCRIPTION
Follow up to https://github.com/googleapis/gapic-showcase/pull/1422:

https://github.com/googleapis/gapic-showcase/actions/runs/7495297257/job/20405070885 shows:

```
Run echo "GITHUB_UPLOAD_URL=[https://uploads.github.com/repos/googleapis/gapic-showcase/releases/136547281/assets{?name,label}](https://uploads.github.com/repos/googleapis/gapic-showcase/releases/136547281/assets%7B?name,label})" >> $GITHUB_ENV
  echo "GITHUB_UPLOAD_URL=https://uploads.github.com/repos/googleapis/gapic-showcase/releases/136547[2](https://github.com/googleapis/gapic-showcase/actions/runs/7495297257/job/20405070885#step:4:2)81/assets{?name,label}" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    TAG_NAME: v0.[3](https://github.com/googleapis/gapic-showcase/actions/runs/7495297257/job/20405070885#step:4:3)0.0
```

So we are getting the upload_url correctly (yay!). But it's not getting passed through to the `binary_assets` job. Github environment variables are not passed between jobs, so I have updated the workflow to use Github Output instead, per: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs