### PR TITLE
chore: fix workflow upload url

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -87,7 +87,7 @@ jobs:
           AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}"
           MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}"
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Determine which upload URL to use
+        name: Determine which upload URL to use
         id: determine_upload_url
         run: |
           echo "automated URL: ${{ AUTO_UPLOAD_URL }}"

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -86,15 +86,16 @@ jobs:
       - env:
           AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}"
           MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}"
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Determine which upload URL to use
         id: determine_upload_url
         run: |
           echo "automated URL: ${{ AUTO_UPLOAD_URL }}"
           echo "manual URL: ${{ MANUAL_UPLOAD_URL }}"
           if [[ -n "${{ AUTO_UPLOAD_URL }}" ]]; then
-          echo "GITHUB_UPLOAD_URL=${{ AUTO_UPLOAD_URL }}" >> $GITHUB_ENV
+          echo "GITHUB_UPLOAD_URL=${{ AUTO_UPLOAD_URL }}" >> "$GITHUB_OUTPUT"
           else
-          echo "GITHUB_UPLOAD_URL=${{ MANUAL_UPLOAD_URL }}" >> $GITHUB_ENV
+          echo "GITHUB_UPLOAD_URL=${{ MANUAL_UPLOAD_URL }}" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/setup-go@v5
         with:
@@ -120,11 +121,8 @@ jobs:
           tar cvfz gapic-showcase.tar.gz gapic-showcase*
       - name: Upload the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} release.
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_UPLOAD_URL: ${{ env.GITHUB_UPLOAD_URL }}
         with:
-          upload_url: ${{ env.GITHUB_UPLOAD_URL }}
+          upload_url: ${{ steps.determine_upload_url.outputs.GITHUB_UPLOAD_URL }}
           asset_path: ./gapic-showcase.tar.gz
           asset_name: gapic-showcase-${{ steps.raw_tag.outputs.raw_version }}-${{ matrix.osarch.os }}-${{ matrix.osarch.arch }}.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -83,15 +83,18 @@ jobs:
           - os: windows
             arch: amd64
     steps:
+      - env:
+          AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}"
+          MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}"
       - name: Determine which upload URL to use
         id: determine_upload_url
         run: |
-          echo "automated URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}"
-          echo "manual URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}"
-          if [[ -n "${{ needs.get-upload-url.outputs.automated_upload_url }}" ]]; then
-          echo "GITHUB_UPLOAD_URL=${{ needs.get-upload-url.outputs.automated_upload_url }}" >> $GITHUB_ENV
+          echo "automated URL: ${{ AUTO_UPLOAD_URL }}"
+          echo "manual URL: ${{ MANUAL_UPLOAD_URL }}"
+          if [[ -n "${{ AUTO_UPLOAD_URL }}" ]]; then
+          echo "GITHUB_UPLOAD_URL=${{ AUTO_UPLOAD_URL }}" >> $GITHUB_ENV
           else
-          echo "GITHUB_UPLOAD_URL=${{ needs.get-upload-url.outputs.manual_upload_url }}" >> $GITHUB_ENV
+          echo "GITHUB_UPLOAD_URL=${{ MANUAL_UPLOAD_URL }}" >> $GITHUB_ENV
           fi
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Follow up to https://github.com/googleapis/gapic-showcase/pull/1425

Upon reading https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs more closely, I am setting the outputs from `get-upload-url` as environment variable before using them instead of using them directly.