### PR TITLE
chore: move env under job instead of steps

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -69,6 +69,10 @@ jobs:
   binary-assets:
     runs-on: ubuntu-latest
     needs: [get-upload-url, proto-assets]
+    env:
+      AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}
+      MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       matrix:
         osarch:
@@ -83,11 +87,7 @@ jobs:
           - os: windows
             arch: amd64
     steps:
-      - env:
-          AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}
-          MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}
-          GITHUB_TOKEN: ${{ github.token }}
-        name: Determine which upload URL to use
+      - name: Determine which upload URL to use
         id: determine_upload_url
         run: |
           echo "automated URL: ${{ AUTO_UPLOAD_URL }}"


### PR DESCRIPTION
From: https://github.com/googleapis/gapic-showcase/actions/runs/7506233217
Getting an invalid syntax error:

```
[Invalid workflow file: .github/workflows/assets.yaml#L92](https://github.com/googleapis/gapic-showcase/actions/runs/7506233217/workflow)
The workflow is not valid. .github/workflows/assets.yaml (Line: 92, Col: 14): Unrecognized named-value: 'AUTO_UPLOAD_URL'. Located at position 1 within expression: AUTO_UPLOAD_URL
```

Moving the `env` piece to be under the job instead of under `steps` to see if that resolves the issue.