### PR TITLE
feat: add request id as part of EchoResponse

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -224,6 +224,9 @@ message EchoResponse {
 
   // The severity specified in the request.
   Severity severity = 2;
+
+  // The request ID specified or autopopulated in the request.
+  string request_id = 3;
 }
 
 // The request message used for the EchoErrorDetails method.

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -51,7 +51,7 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 	}
 	echoHeaders(ctx)
 	echoTrailers(ctx)
-	return &pb.EchoResponse{Content: in.GetContent(), Severity: in.GetSeverity()}, nil
+	return &pb.EchoResponse{Content: in.GetContent(), Severity: in.GetSeverity(), RequestId: in.GetRequestId()}, nil
 }
 
 func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorDetailsRequest) (*pb.EchoErrorDetailsResponse, error) {


### PR DESCRIPTION
To make it easier to check what request ID is sent as part of the request, this PR adds it to EchoResponse so tests can check the response directly.