### PR TITLE
fix: add test case for server streaming with common response

### DIFF
--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -171,7 +171,7 @@ service Messaging {
   }
 
   // This returns a stream which is an HTTP payload including HTTP headers.
-  rpc StreamBlurbs(StreamBlurbsRequest) returns (stream google.api.HttpBody) {
+  rpc StreamBlurbsHttpBody(StreamBlurbsRequest) returns (stream google.api.HttpBody) {
     option (google.api.http) = {
       post: "/v1beta1/{name=rooms/*}/blurbs:stream"
       body: "*"

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -169,6 +169,18 @@ service Messaging {
     };
   }
 
+  // This returns a stream which is an HTTP payload including HTTP headers:
+  rpc StreamBlurbs(StreamBlurbsRequest) returns (stream google.api.HttpBody) {
+    option (google.api.http) = {
+      post: "/v1beta1/{name=rooms/*}/blurbs:stream"
+      body: "*"
+      additional_bindings: {
+        post: "/v1beta1/{name=users/*/profile}/blurbs:stream"
+        body: "*"
+      }
+    };
+  }
+
   // This is a stream to create multiple blurbs. If an invalid blurb is
   // requested to be created, the stream will close with an error.
   rpc SendBlurbs(stream CreateBlurbRequest) returns (SendBlurbsResponse) {

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -169,7 +169,7 @@ service Messaging {
     };
   }
 
-  // This returns a stream which is an HTTP payload including HTTP headers:
+  // This returns a stream which is an HTTP payload including HTTP headers.
   rpc StreamBlurbs(StreamBlurbsRequest) returns (stream google.api.HttpBody) {
     option (google.api.http) = {
       post: "/v1beta1/{name=rooms/*}/blurbs:stream"

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
+import "google/api/httpbody.proto";
 import "google/api/resource.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -173,7 +173,7 @@ service Messaging {
   // This returns a stream which is an HTTP payload including HTTP headers.
   rpc StreamBlurbsHttpBody(StreamBlurbsRequest) returns (stream google.api.HttpBody) {
     option (google.api.http) = {
-      post: "/v1beta1/{name=rooms/*}/blurbs:stream"
+      post: "/v1beta1/{name=rooms/*}/blurbs:streamhttp"
       body: "*"
       additional_bindings: {
         post: "/v1beta1/{name=users/*/profile}/blurbs:stream"

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -176,7 +176,7 @@ service Messaging {
       post: "/v1beta1/{name=rooms/*}/blurbs:streamhttp"
       body: "*"
       additional_bindings: {
-        post: "/v1beta1/{name=users/*/profile}/blurbs:stream"
+        post: "/v1beta1/{name=users/*/profile}/blurbs:streamhttp"
         body: "*"
       }
     };


### PR DESCRIPTION
This PR adds a server side streaming test case which failed in the python GAPIC generator (b/311671723). The response type that failed was from common protos (https://google.aip.dev/213) rather than from the API. The reason that we saw this issue in python is because for certain common protos we don’t use proto-plus and we need to handle the response in a different way.

We added the test case to `gapic-generator-python` in https://github.com/googleapis/gapic-generator-python/pull/1942 and we would like to propose adding the test case to the showcase test suite.