### PR TITLE
feat(errors): allow Echo  to auto-populate fake error details

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -215,6 +215,11 @@ message EchoRequest {
   string request_id = 7 [
     (google.api.field_info).format = UUID4
   ];
+
+  // If `error` is set, then this flag causes the Showcase server to append
+  // multiple fake error details in the error response. This is useful for
+  // testing client behavior on error responses.
+  bool generate_error_details = 8;
 }
 
 // The response message for the Echo methods.


### PR DESCRIPTION
This is useful for testing client responses to errors.

This can be tested over REST with

curl -i -X POST http://localhost:7469/v1beta1/echo:echo \
   -d'{"error": {"code": 8}, "generateErrorDetails": true}' \
   -H "Content-Type: application/json" -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0"