### PR TITLE
feat: Add autopopulated proto3 optional field to echo

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -211,8 +211,13 @@ message EchoRequest {
   // Optional. This field can be set to test the routing annotation on the Echo method.
   string other_header = 5;
 
-  // Based on go/client-populate-request-id-design; subject to change
+  // To facilitate testing of https://google.aip.dev/client-libraries/4235
   string request_id = 7 [
+    (google.api.field_info).format = UUID4
+  ];
+
+  // To facilitate testing of https://google.aip.dev/client-libraries/4235
+  optional string other_request_id = 7 [
     (google.api.field_info).format = UUID4
   ];
 }
@@ -227,6 +232,9 @@ message EchoResponse {
 
   // The request ID specified or autopopulated in the request.
   string request_id = 3;
+
+  // The other request ID specified or autopopulated in the request.
+  string other_request_id = 3;
 }
 
 // The request message used for the EchoErrorDetails method.

--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -217,7 +217,7 @@ message EchoRequest {
   ];
 
   // To facilitate testing of https://google.aip.dev/client-libraries/4235
-  optional string other_request_id = 7 [
+  optional string other_request_id = 8 [
     (google.api.field_info).format = UUID4
   ];
 }
@@ -234,7 +234,7 @@ message EchoResponse {
   string request_id = 3;
 
   // The other request ID specified or autopopulated in the request.
-  string other_request_id = 3;
+  string other_request_id = 4;
 }
 
 // The request message used for the EchoErrorDetails method.

--- a/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
+++ b/schema/google/showcase/v1beta1/showcase_v1beta1.yaml
@@ -88,3 +88,4 @@ publishing:
   - selector: google.showcase.v1beta1.Echo.Echo
     auto_populated_fields:
     - request_id
+    - other_request_id

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -51,7 +51,7 @@ func (s *echoServerImpl) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.Echo
 	}
 	echoHeaders(ctx)
 	echoTrailers(ctx)
-	return &pb.EchoResponse{Content: in.GetContent(), Severity: in.GetSeverity(), RequestId: in.GetRequestId()}, nil
+	return &pb.EchoResponse{Content: in.GetContent(), Severity: in.GetSeverity(), RequestId: in.GetRequestId(), OtherRequestId: in.GetOtherRequestId()}, nil
 }
 
 func (s *echoServerImpl) EchoErrorDetails(ctx context.Context, in *pb.EchoErrorDetailsRequest) (*pb.EchoErrorDetailsResponse, error) {


### PR DESCRIPTION
To test the `The field supports explicit presence, and has not been set by the user` requirement of [AIP-4235](https://google.aip.dev/client-libraries/4235)

```
The field must be automatically populated if and only if one of the following conditions holds:

The field supports explicit presence, and has not been set by the user
The field doesn't support explicit presence, and its value is the empty string (i.e. the default value)
```