### PR TITLE
chore: make core-client-libraries CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-* @googleapis/actools @googleapis/cloud-java-team-teamsync
+* @googleapis/core-client-libraries @googleapis/cloud-java-team-teamsync


### PR DESCRIPTION
Switch from `actools` to `core-client-libraries`, which is the latest, up-to-date GitHub Team.