### PR TITLE
chore(deps): stop bazel protobuf updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,12 @@
   "bazel": {
     "managerBranchPrefix": "bazel-"
   },
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["com_google_protobuf"],
+      "enabled": false
+    }
+  ]
   "golang": {
     "postUpdateOptions": [
       "gomodTidy"


### PR DESCRIPTION
Protobuf v26 has some breaking changes and in general we need to wait to take it, so let's pause updating it for the time being.