### PR TITLE
feat(server): echo request headers in response over REST transport

### DIFF
--- a/util/genrest/goviewcreator.go
+++ b/util/genrest/goviewcreator.go
@@ -93,6 +93,8 @@ func NewView(model *gomodel.Model) (*goview.View, error) {
 			source.P(`  backend.StdLog.Printf("  urlPathParams (expect %d, have %%d): %%q", numUrlPathParams, urlPathParams)`, len(allURLVariables))
 			source.P(`  backend.StdLog.Printf("  urlRequestHeaders:\n%%s", resttools.PrettyPrintHeaders(r, "    "))`)
 			source.P("")
+			source.P("  resttools.IncludeRequestHeadersInResponse(w, r)")
+			source.P("")
 			source.P("  if numUrlPathParams!=%d {", len(allURLVariables))
 			source.P(`    backend.Error(w, http.StatusBadRequest, "found unexpected number of URL variables: expected %d, have %%d: %%#v", numUrlPathParams, urlPathParams)`, len(allURLVariables))
 			source.P("    return")

--- a/util/genrest/resttools/headers.go
+++ b/util/genrest/resttools/headers.go
@@ -98,3 +98,16 @@ func PrettyPrintHeaders(request *http.Request, indentation string) string {
 	}
 	return strings.Join(lines, "\n")
 }
+
+// IncludeRequestHeadersInResponse includes all headers in the request `r` and includes them in the response `w`,
+// prefixing each of these header keys with a constant to reflect they came from the request.
+func IncludeRequestHeadersInResponse(w http.ResponseWriter, r *http.Request) {
+	const prefix = "x-showcase-request-"
+
+	responseHeaders := w.Header()
+	for requestKey, valueList := range r.Header {
+		for _, value := range valueList {
+			responseHeaders.Add(prefix+requestKey, value)
+		}
+	}
+}


### PR DESCRIPTION
Towards #1493, but note that this will occur for all Showcase services, not just `Echo`. 

This can be verified manually on the shell via:

```
❯ curl -i -X POST -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0" -H 'Content-Type: application/json' http://localhost:7469/v1beta1/echo:echo -d'{"content":"g
reetings"}'                                                                                                                                                 
HTTP/1.1 200 OK
X-Showcase-Request-Accept: */*
X-Showcase-Request-Content-Length: 23
X-Showcase-Request-Content-Type: application/json
X-Showcase-Request-User-Agent: curl/8.5.0
X-Showcase-Request-X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0
Date: Fri, 26 Apr 2024 21:33:24 GMT
Content-Length: 104
Content-Type: text/plain; charset=utf-8

{
  "content":  "greetings",
  "severity":  "UNNECESSARY",
  "requestId":  "",
  "otherRequestId":  ""
}
```

and works even for error responses:

```
❯ curl -i -X POST -H "X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0" -H 'Content-Type: application/json' http://localhost:7469/v1beta1/echo:echo -d'{"foo":"greet
ings"}'                                                                                                                                                     
HTTP/1.1 400 Bad Request
X-Showcase-Request-Accept: */*
X-Showcase-Request-Content-Length: 19
X-Showcase-Request-Content-Type: application/json
X-Showcase-Request-User-Agent: curl/8.5.0
X-Showcase-Request-X-Goog-Api-Client: rest/0.0.0 gapic/0.0.0
Date: Fri, 26 Apr 2024 21:47:05 GMT
Content-Length: 160
Content-Type: text/plain; charset=utf-8

{"error":{"code":400,"message":"error reading body params '*': proto: (line 1:2): unknown field \"foo\"","details":null,"Body":"","Header":null,"Errors":null}
```