### PR TITLE
chore(cmd,server): replace use of google.golang.org/genproto/googleapis/longrunning

### DIFF
--- a/server/services/services.go
+++ b/server/services/services.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
+	locpb "google.golang.org/genproto/googleapis/cloud/location"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
-	locpb "google.golang.org/genproto/googleapis/cloud/location"
 )
 
 // Backend contains the various service backends that will be


### PR DESCRIPTION
Replace use of google.golang.org/genproto/googleapis/longrunning with cloud.google.com/go/longrunning/autogen/longrunningpb.

Fixes #1527