### PR TITLE
Prototype: Add stub for auth echo service.

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -180,6 +180,15 @@ service Echo {
       body: "*"
     };
   };
+
+  // This method returns authentication details from the incoming request, including things like
+  // Authorization headers for clients to verify that the correct headers are being sent.
+  rpc EchoAuthentication(EchoAuthenticationRequest) returns (EchoAuthenticationResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/echo:authentication"
+      body: "*"
+    }
+  };
 }
 
 // A severity enum used to test enum capabilities in GAPIC surfaces.
@@ -389,4 +398,15 @@ message BlockResponse {
   // This content can contain anything, the server will not depend on a value
   // here.
   string content = 1;
+}
+
+// The request for EchoAuthentication method.  This is currently empty but
+// is included as a unique message (not Empty) in case we need to add to it
+// later.
+message EchoAuthenticationRequest {
+}
+
+// The response for the EchoAuthentication method.
+message EchoAuthenticationResponse {
+  repeated string headers = 1;
 }

--- a/server/services/echo_service.go
+++ b/server/services/echo_service.go
@@ -158,6 +158,10 @@ func (s *echoServerImpl) Chat(stream pb.Echo_ChatServer) error {
 	}
 }
 
+func (s *echoServerImpl) EchoAuthentication(ctx context.Context, in *pb.EchoAuthenticationRequest) (*pb.EchoAuthenticationResponse, error) {
+	// Stuff the Authorization header from the context into the response.
+}
+
 func (s *echoServerImpl) PagedExpandLegacy(ctx context.Context, in *pb.PagedExpandLegacyRequest) (*pb.PagedExpandResponse, error) {
 	req := &pb.PagedExpandRequest{
 		Content:   in.Content,


### PR DESCRIPTION
DO NOT MERGE

This will provide back to clients at least the contents of the Authorization header, so they can verify that tokens were transmitted appropriately.