### PR TITLE
fix: revert "replace use of github.com/golang/protobuf/proto (#1534)"

### DIFF
--- a/cmd/gapic-showcase/gapic-showcase.go
+++ b/cmd/gapic-showcase/gapic-showcase.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/proto"
 )
 
 var Verbose, OutputJSON bool

--- a/server/services/echo_service_test.go
+++ b/server/services/echo_service_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	durpb "github.com/golang/protobuf/ptypes/duration"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
@@ -33,7 +34,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 )
 

--- a/server/services/iam_policy_service.go
+++ b/server/services/iam_policy_service.go
@@ -19,9 +19,9 @@ import (
 	"sync"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 var missingResource error = status.Error(codes.InvalidArgument, "Missing required argument: resource")

--- a/server/services/identity_service.go
+++ b/server/services/identity_service.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewIdentityServer returns a new instance of showcase identity server.

--- a/server/services/identity_service_test.go
+++ b/server/services/identity_service_test.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 

--- a/server/services/messaging_service.go
+++ b/server/services/messaging_service.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleapis/gapic-showcase/server"
@@ -32,7 +33,6 @@ import (
 	errdetails "google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewMessagingServer returns an instance of a messaging server.

--- a/server/services/messaging_service_test.go
+++ b/server/services/messaging_service_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
@@ -32,7 +33,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 

--- a/server/services/operations_service.go
+++ b/server/services/operations_service.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // NewOperationsServer returns a new OperationsServer for the Showcase API.

--- a/server/services/operations_service_test.go
+++ b/server/services/operations_service_test.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestGetOperation_wait(t *testing.T) {

--- a/server/services/testing_service_test.go
+++ b/server/services/testing_service_test.go
@@ -19,12 +19,12 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 func Test_Session_lifecycle(t *testing.T) {

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestSessionProto(t *testing.T) {

--- a/server/spec/v1/unary.go
+++ b/server/spec/v1/unary.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/googleapis/gapic-showcase/server"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 type unaryTest struct {

--- a/server/spec/v1/unary_test.go
+++ b/server/spec/v1/unary_test.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 func Test_unaryTest_GetName(t *testing.T) {

--- a/server/waiter.go
+++ b/server/waiter.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
-	"google.golang.org/protobuf/proto"
 )
 
 var waiterSingleton Waiter = &waiterImpl{

--- a/server/waiter_test.go
+++ b/server/waiter_test.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestGetWaiterInstance(t *testing.T) {

--- a/util/genrest/internal/pbinfo/pbinfo.go
+++ b/util/genrest/internal/pbinfo/pbinfo.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"google.golang.org/protobuf/proto"
 )
 
 // ProtoType represents a type in protobuf descriptors.


### PR DESCRIPTION
This reverts commit b9f8777913ed19a4c6de375857364133a92c63f7. This was breaking `go build`