### PR TITLE
chore(ci): run go build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,8 @@ jobs:
         rm regen.tgz
     - name: Run mod tidy
       run: go mod tidy
+    - name: Build the code
+      run: go build ./...
     - name: Run unit tests
       run: go test ./...
     - name: Run server coverage


### PR DESCRIPTION
This would have caught some previous build failures that were not caught by simply running the tests.