### PR TITLE
chore: allow workflow_dispatch on ci.yaml action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   regenerate:


### PR DESCRIPTION
This is useful for debugging CI/build issues. Motivated by #1577.