### PR TITLE
build: fix assets action by fixing GitHub token access

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload proto release assets
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ github.token }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./dist/*
           tag: ${{ env.TAG_NAME }}
           overwrite: true
@@ -68,7 +68,7 @@ jobs:
     env:
       AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}
       MANUAL_UPLOAD_URL: ${{ needs.get-upload-url.outputs.manual_upload_url }}
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         osarch:

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -66,6 +66,8 @@ jobs:
           file_glob: true
   binary-assets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [get-upload-url, proto-assets]
     env:
       AUTO_UPLOAD_URL: ${{ needs.get-upload-url.outputs.automated_upload_url }}

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -39,6 +39,8 @@ jobs:
             core.setOutput("MANUAL_UPLOAD_URL", release.data.upload_url);
   proto-assets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Refs:
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
- https://github.com/svenstaro/upload-release-action?tab=readme-ov-file#permissions