### PR TITLE
fix: gapic showcase proto compliance

### DIFF
--- a/schema/google/showcase/v1beta1/echo.proto
+++ b/schema/google/showcase/v1beta1/echo.proto
@@ -361,9 +361,7 @@ message PagedExpandResponseList {
 
 message PagedExpandLegacyMappedResponse {
   // The words that were expanded, indexed by their initial character.
-  // (-- aip.dev/not-precedent: This is a legacy, non-standard pattern that violates
-  //     aip.dev/158. Ordinarily, this should be a `repeated` field, as in PagedExpandResponse. --)
-  map<string, PagedExpandResponseList> alphabetized = 1;
+  repeated PagedExpandResponseList alphabetized = 1;
 
   // The next page token.
   string next_page_token = 2;

--- a/schema/google/showcase/v1beta1/identity.proto
+++ b/schema/google/showcase/v1beta1/identity.proto
@@ -41,9 +41,7 @@ service Identity {
       post: "/v1beta1/users"
       body: "*"
     };
-    option (google.api.method_signature) = "user.display_name,user.email";
-    option (google.api.method_signature) =
-        "user.display_name,user.email,user.age,user.nickname,user.enable_notifications,user.height_feet";
+    option (google.api.method_signature) = "user";
   }
 
   // Retrieves the User with the given uri.

--- a/schema/google/showcase/v1beta1/messaging.proto
+++ b/schema/google/showcase/v1beta1/messaging.proto
@@ -30,6 +30,10 @@ option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
 option java_package = "com.google.showcase.v1beta1";
 option java_multiple_files = true;
 option ruby_package = "Google::Showcase::V1beta1";
+option (google.api.resource_definition) = {
+  type: "showcase.googleapis.com/User"
+  pattern: "users/{user}"
+};
 
 // A simple messaging service that implements chat rooms and profile posts.
 //
@@ -46,7 +50,7 @@ service Messaging {
       post: "/v1beta1/rooms"
       body: "*"
     };
-    option (google.api.method_signature) = "room.display_name,room.description";
+    option (google.api.method_signature) = "room";
   }
 
   // Retrieves the Room with the given resource name.
@@ -92,8 +96,7 @@ service Messaging {
         body: "*"
       }
     };
-    option (google.api.method_signature) = "parent,blurb.user,blurb.text";
-    option (google.api.method_signature) = "parent,blurb.user,blurb.image";
+    option (google.api.method_signature) = "parent,blurb";
   }
 
   // Retrieves the Blurb with the given resource name.
@@ -194,6 +197,7 @@ message Room {
   option (google.api.resource) = {
     type: "showcase.googleapis.com/Room"
     pattern: "rooms/{room}"
+    pattern: "rooms/{room}/legacy_room/{legacy_room}"
   };
 
   // The resource name of the chat room.
@@ -283,10 +287,10 @@ message ListRoomsResponse {
 message Blurb {
   option (google.api.resource) = {
     type: "showcase.googleapis.com/Blurb"
-    pattern: "users/{user}/profile/blurbs/legacy/{legacy_user}~{blurb}"
-    pattern: "users/{user}/profile/blurbs/{blurb}"
+    pattern: "users/{user}/blurbs/{blurb}"
     pattern: "rooms/{room}/blurbs/{blurb}"
-    pattern: "rooms/{room}/blurbs/legacy/{legacy_room}.{blurb}"
+    pattern: "rooms/{room}/legacy_room/{legacy_room}/blurbs/{blurb}"
+    pattern: "users/{user}/blurbs/{blurb}/legacy/{legacy_user}"
   };
 
   // The resource name of the chat room.


### PR DESCRIPTION
These are fixes that were required for the PHP client libraries to build. Notably they:

- remove "nested" references from `method_signature` annotations
- use standard paths for `resource.pattern`
- uses `repeated` instead of `map` for pagination