### PR TITLE
feat: add resumable upload error scenarios

### DIFF
--- a/server/resumableupload/README.md
+++ b/server/resumableupload/README.md
@@ -22,3 +22,23 @@ The middleware inspects `X-Goog-Upload-Command` and implements the core session 
 - **`upload, finalize`**: Commits the final chunk, sets session status to `final`, and returns the JSON response `{"name":"<id>","size":<total_bytes>}`.
 - **`query`**: Queries current session status and returns `X-Goog-Upload-Status` and `X-Goog-Upload-Size-Received` (`200 OK` for active/final sessions; `410 Gone` for cancelled sessions).
 - **`cancel`**: Cancels the session (`X-Goog-Upload-Status: cancelled`).
+
+---
+
+## 3. Test Scenarios & Failure Injection
+
+The middleware supports injecting failure scenarios via HTTP headers for testing client retry and error-recovery behavior:
+
+- **`X-Goog-Test-Scenario`**: Specifies the scenario (`non_fatal_error_on_start`, `fatal_error_on_start`, `non_fatal_error_on_chunk_upload`, `non_fatal_error_on_query`, `chunk_granularity`).
+- **`X-Goog-Test-Scenario-Config`**: JSON configuration string controlling the injected error (`client_uuid`, `error_code`, `failure_count`, `after_offset`, `action_after_failures`).
+
+### Start-Call Scenario Isolation (`client_uuid`)
+Because `start` commands occur before a session ID (`sid`) is generated, failure counts for `non_fatal_error_on_start` are tracked per `client_uuid` (or remote address if omitted). Passing a unique `client_uuid` in `X-Goog-Test-Scenario-Config` ensures concurrent test executions do not collide:
+
+```json
+{
+  "client_uuid": "test-client-run-abc",
+  "error_code": 503,
+  "failure_count": 1
+}
+```

--- a/server/resumableupload/resumableupload.go
+++ b/server/resumableupload/resumableupload.go
@@ -289,7 +289,10 @@ func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request) {
 		AfterOffset:         0,
 	}
 	if cfgStr := r.Header.Get("X-Goog-Test-Scenario-Config"); cfgStr != "" {
-		_ = json.Unmarshal([]byte(cfgStr), &config)
+		if err := json.Unmarshal([]byte(cfgStr), &config); err != nil {
+			sendError(w, http.StatusBadRequest, "Invalid JSON in X-Goog-Test-Scenario-Config header", "")
+			return
+		}
 	}
 
 	lookupKey := scenario + "-" + r.RemoteAddr

--- a/server/resumableupload/resumableupload.go
+++ b/server/resumableupload/resumableupload.go
@@ -16,6 +16,7 @@ package resumableupload
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,22 +38,98 @@ const (
 	statusCancelled status = "cancelled"
 )
 
+type ScenarioConfig struct {
+	ClientUUID          string `json:"client_uuid"`
+	ErrorCode           int    `json:"error_code"`
+	FailureCount        int    `json:"failure_count"`
+	ActionAfterFailures string `json:"action_after_failures"`
+	AfterOffset         int64  `json:"after_offset"`
+}
+
 type uploadSession struct {
-	ID            string
-	CurrentOffset int64
-	Buffer        bytes.Buffer
-	Status        status
-	mu            sync.Mutex
+	ID             string
+	CurrentOffset  int64
+	Buffer         bytes.Buffer
+	Status         status
+	Scenario       string
+	ScenarioConfig ScenarioConfig
+	UploadFailures int
+	mu             sync.Mutex
+}
+
+func (sess *uploadSession) handleScenario(cmd string, w http.ResponseWriter, r *http.Request, offset int64) bool {
+	switch sess.Scenario {
+	case "non_fatal_error_on_query":
+		return sess.nonFatalErrorOnQuery(cmd, w)
+	case "non_fatal_error_on_chunk_upload":
+		return sess.nonFatalErrorOnChunkUpload(cmd, w, offset)
+	case "chunk_granularity":
+		return sess.chunkGranularity(cmd, w, r)
+	default:
+		return false
+	}
+}
+
+func (sess *uploadSession) nonFatalErrorOnQuery(cmd string, w http.ResponseWriter) bool {
+	if cmd == "query" && sess.UploadFailures < sess.ScenarioConfig.FailureCount {
+		sess.UploadFailures++
+		sendError(w, sess.ScenarioConfig.ErrorCode, "Injected non-fatal query error", statusActive)
+		return true
+	}
+	return false
+}
+
+func (sess *uploadSession) nonFatalErrorOnChunkUpload(cmd string, w http.ResponseWriter, offset int64) bool {
+	if cmd == "upload" && offset >= sess.ScenarioConfig.AfterOffset {
+		if sess.UploadFailures < sess.ScenarioConfig.FailureCount {
+			sess.UploadFailures++
+			sendError(w, sess.ScenarioConfig.ErrorCode, "Injected non-fatal chunk upload error", statusActive)
+			return true
+		}
+		if sess.ScenarioConfig.ActionAfterFailures == "terminate" {
+			sendError(w, http.StatusInternalServerError, "Scenario requested termination", "")
+			return true
+		}
+	}
+	return false
+}
+
+func (sess *uploadSession) chunkGranularity(cmd string, w http.ResponseWriter, r *http.Request) bool {
+	if cmd == "upload" {
+		commands := parseCommands(r.Header.Get("X-Goog-Upload-Command"))
+		if !slices.Contains(commands, "finalize") {
+			bodyLen := r.ContentLength
+			if bodyLen > 0 && bodyLen%256 != 0 {
+				sendError(w, http.StatusBadRequest, fmt.Sprintf("Chunk size %d is not a multiple of granularity 256", bodyLen), statusActive)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type Manager struct {
-	sessions sync.Map
-	idGen    int64
+	sessions        sync.Map
+	startFailureMap sync.Map
+	idGen           int64
 }
 
 // NewManager creates a new Resumable Upload session manager.
 func NewManager() *Manager {
 	return &Manager{}
+}
+
+func (m *Manager) incrementStartFailure(key, scenario string, limit int) int {
+	if scenario != "non_fatal_error_on_start" {
+		return limit + 1
+	}
+	val, _ := m.startFailureMap.LoadOrStore(key, new(int32))
+	ptr := val.(*int32)
+	current := int(atomic.AddInt32(ptr, 1))
+	if current > limit {
+		atomic.StoreInt32(ptr, 0)
+	}
+	return current
 }
 
 // Middleware returns an HTTP middleware that handles Resumable Upload protocol requests.
@@ -72,6 +149,9 @@ func (m *Manager) Middleware(next http.Handler) http.Handler {
 }
 
 func (sess *uploadSession) query(w http.ResponseWriter) {
+	if sess.handleScenario("query", w, nil, 0) {
+		return
+	}
 	w.Header().Set("X-Goog-Upload-Status", string(sess.Status))
 	if sess.Status == statusCancelled {
 		w.WriteHeader(http.StatusGone)
@@ -101,6 +181,10 @@ func (sess *uploadSession) cancel(w http.ResponseWriter) {
 func (sess *uploadSession) upload(w http.ResponseWriter, r *http.Request, offset int64) bool {
 	if sess.Status != statusActive {
 		sendError(w, http.StatusBadRequest, fmt.Sprintf("Cannot upload to session with status %s", sess.Status), sess.Status)
+		return false
+	}
+
+	if sess.handleScenario("upload", w, r, offset) {
 		return false
 	}
 
@@ -193,12 +277,48 @@ func (m *Manager) handleRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request) {
+	scenario := r.Header.Get("X-Goog-Test-Scenario")
+	if scenario == "" {
+		scenario = "happy_path"
+	}
+
+	config := ScenarioConfig{
+		ErrorCode:           http.StatusServiceUnavailable,
+		FailureCount:        1,
+		ActionAfterFailures: "succeed",
+		AfterOffset:         0,
+	}
+	if cfgStr := r.Header.Get("X-Goog-Test-Scenario-Config"); cfgStr != "" {
+		_ = json.Unmarshal([]byte(cfgStr), &config)
+	}
+
+	lookupKey := scenario + "-" + r.RemoteAddr
+	if config.ClientUUID != "" {
+		lookupKey = scenario + "-" + config.ClientUUID
+	}
+
+	failures := m.incrementStartFailure(lookupKey, scenario, config.FailureCount)
+	if scenario == "non_fatal_error_on_start" && failures <= config.FailureCount {
+		sendError(w, config.ErrorCode, "Injected non-fatal start error", "")
+		return
+	}
+	if scenario == "fatal_error_on_start" {
+		code := config.ErrorCode
+		if code == 0 {
+			code = http.StatusForbidden
+		}
+		sendError(w, code, "Injected fatal start error", "")
+		return
+	}
+
 	id := atomic.AddInt64(&m.idGen, 1)
 	sid := fmt.Sprintf("scotty-sid-%d", id)
 
 	sess := &uploadSession{
-		ID:     sid,
-		Status: statusActive,
+		ID:             sid,
+		Status:         statusActive,
+		Scenario:       scenario,
+		ScenarioConfig: config,
 	}
 	m.sessions.Store(sid, sess)
 
@@ -224,10 +344,14 @@ func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 	uploadURL := newUrl.String()
 
+	granularity := strconv.Itoa(256 * 1024)
+	if scenario == "chunk_granularity" {
+		granularity = "256"
+	}
 	w.Header().Set("X-Goog-Upload-Status", string(statusActive))
 	w.Header().Set("X-Goog-Upload-URL", uploadURL)
 	w.Header().Set("X-Goog-Upload-Control-URL", uploadURL)
-	w.Header().Set("X-Goog-Upload-Chunk-Granularity", strconv.Itoa(256*1024))
+	w.Header().Set("X-Goog-Upload-Chunk-Granularity", granularity)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/server/resumableupload/resumableupload_test.go
+++ b/server/resumableupload/resumableupload_test.go
@@ -227,3 +227,227 @@ func TestNonFatalStartErrorWithClientUUID(t *testing.T) {
 		t.Fatalf("expected 503 Service Unavailable on first start for client-b, got %d", recB1.Code)
 	}
 }
+
+func TestInvalidScenarioConfigJSON(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	req := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	req.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	req.Header.Set("X-Goog-Upload-Command", "start")
+	req.Header.Set("X-Goog-Test-Scenario-Config", "{invalid-json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request on invalid scenario config JSON, got %d", rec.Code)
+	}
+}
+
+func TestFatalErrorOnStartScenario(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	// Default error code (503 Service Unavailable)
+	req1 := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	req1.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	req1.Header.Set("X-Goog-Upload-Command", "start")
+	req1.Header.Set("X-Goog-Test-Scenario", "fatal_error_on_start")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable on fatal_error_on_start default, got %d", rec1.Code)
+	}
+
+	// Configured custom error code (403 Forbidden)
+	req2 := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	req2.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	req2.Header.Set("X-Goog-Upload-Command", "start")
+	req2.Header.Set("X-Goog-Test-Scenario", "fatal_error_on_start")
+	req2.Header.Set("X-Goog-Test-Scenario-Config", `{"error_code":403}`)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden on fatal_error_on_start custom config, got %d", rec2.Code)
+	}
+}
+
+func TestNonFatalErrorOnChunkUploadScenario(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	reqStart := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqStart.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqStart.Header.Set("X-Goog-Upload-Command", "start")
+	reqStart.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_chunk_upload")
+	reqStart.Header.Set("X-Goog-Test-Scenario-Config", `{"error_code":503,"failure_count":1,"after_offset":0}`)
+	recStart := httptest.NewRecorder()
+	handler.ServeHTTP(recStart, reqStart)
+
+	uploadURL := recStart.Header().Get("X-Goog-Upload-URL")
+	u, _ := url.Parse(uploadURL)
+
+	// First upload attempt fails with injected 503
+	reqUpload1 := httptest.NewRequest("POST", u.String(), bytes.NewReader([]byte("chunk1")))
+	reqUpload1.Header.Set("X-Goog-Upload-Command", "upload")
+	reqUpload1.Header.Set("X-Goog-Upload-Offset", "0")
+	recUpload1 := httptest.NewRecorder()
+	handler.ServeHTTP(recUpload1, reqUpload1)
+
+	if recUpload1.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable on first chunk upload, got %d", recUpload1.Code)
+	}
+
+	// Second upload attempt succeeds after exhausting failure_count=1
+	reqUpload2 := httptest.NewRequest("POST", u.String(), bytes.NewReader([]byte("chunk1")))
+	reqUpload2.Header.Set("X-Goog-Upload-Command", "upload")
+	reqUpload2.Header.Set("X-Goog-Upload-Offset", "0")
+	recUpload2 := httptest.NewRecorder()
+	handler.ServeHTTP(recUpload2, reqUpload2)
+
+	if recUpload2.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on retry chunk upload, got %d", recUpload2.Code)
+	}
+}
+
+func TestNonFatalErrorOnChunkUploadTerminateScenario(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	reqStart := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqStart.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqStart.Header.Set("X-Goog-Upload-Command", "start")
+	reqStart.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_chunk_upload")
+	reqStart.Header.Set("X-Goog-Test-Scenario-Config", `{"error_code":503,"failure_count":1,"action_after_failures":"terminate"}`)
+	recStart := httptest.NewRecorder()
+	handler.ServeHTTP(recStart, reqStart)
+
+	uploadURL := recStart.Header().Get("X-Goog-Upload-URL")
+	u, _ := url.Parse(uploadURL)
+
+	// First upload attempt fails with injected 503
+	reqUpload1 := httptest.NewRequest("POST", u.String(), bytes.NewReader([]byte("chunk1")))
+	reqUpload1.Header.Set("X-Goog-Upload-Command", "upload")
+	reqUpload1.Header.Set("X-Goog-Upload-Offset", "0")
+	recUpload1 := httptest.NewRecorder()
+	handler.ServeHTTP(recUpload1, reqUpload1)
+
+	if recUpload1.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable on first chunk upload, got %d", recUpload1.Code)
+	}
+
+	// Subsequent upload attempt terminates with 500 Internal Server Error
+	reqUpload2 := httptest.NewRequest("POST", u.String(), bytes.NewReader([]byte("chunk1")))
+	reqUpload2.Header.Set("X-Goog-Upload-Command", "upload")
+	reqUpload2.Header.Set("X-Goog-Upload-Offset", "0")
+	recUpload2 := httptest.NewRecorder()
+	handler.ServeHTTP(recUpload2, reqUpload2)
+
+	if recUpload2.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 Internal Server Error when action_after_failures=terminate, got %d", recUpload2.Code)
+	}
+}
+
+func TestNonFatalErrorOnQueryScenario(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	reqStart := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqStart.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqStart.Header.Set("X-Goog-Upload-Command", "start")
+	reqStart.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_query")
+	reqStart.Header.Set("X-Goog-Test-Scenario-Config", `{"error_code":502,"failure_count":1}`)
+	recStart := httptest.NewRecorder()
+	handler.ServeHTTP(recStart, reqStart)
+
+	uploadURL := recStart.Header().Get("X-Goog-Upload-URL")
+	u, _ := url.Parse(uploadURL)
+
+	// First query attempt fails with injected 502
+	reqQuery1 := httptest.NewRequest("POST", u.String(), nil)
+	reqQuery1.Header.Set("X-Goog-Upload-Command", "query")
+	recQuery1 := httptest.NewRecorder()
+	handler.ServeHTTP(recQuery1, reqQuery1)
+
+	if recQuery1.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 Bad Gateway on first query, got %d", recQuery1.Code)
+	}
+
+	// Second query attempt succeeds after exhausting failure_count=1
+	reqQuery2 := httptest.NewRequest("POST", u.String(), nil)
+	reqQuery2.Header.Set("X-Goog-Upload-Command", "query")
+	recQuery2 := httptest.NewRecorder()
+	handler.ServeHTTP(recQuery2, reqQuery2)
+
+	if recQuery2.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on retry query, got %d", recQuery2.Code)
+	}
+}
+
+func TestChunkGranularityScenario(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	reqStart := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqStart.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqStart.Header.Set("X-Goog-Upload-Command", "start")
+	reqStart.Header.Set("X-Goog-Test-Scenario", "chunk_granularity")
+	recStart := httptest.NewRecorder()
+	handler.ServeHTTP(recStart, reqStart)
+
+	if got, want := recStart.Header().Get("X-Goog-Upload-Chunk-Granularity"), "256"; got != want {
+		t.Fatalf("expected chunk granularity %s on chunk_granularity scenario, got %s", want, got)
+	}
+
+	uploadURL := recStart.Header().Get("X-Goog-Upload-URL")
+	u, _ := url.Parse(uploadURL)
+
+	// Non-final chunk not a multiple of 256 bytes should fail with 400 Bad Request
+	reqInvalid := httptest.NewRequest("POST", u.String(), bytes.NewReader(make([]byte, 100)))
+	reqInvalid.Header.Set("X-Goog-Upload-Command", "upload")
+	reqInvalid.Header.Set("X-Goog-Upload-Offset", "0")
+	recInvalid := httptest.NewRecorder()
+	handler.ServeHTTP(recInvalid, reqInvalid)
+
+	if recInvalid.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request on non-aligned chunk upload, got %d", recInvalid.Code)
+	}
+
+	// Non-final chunk that is a multiple of 256 bytes should succeed
+	reqValid := httptest.NewRequest("POST", u.String(), bytes.NewReader(make([]byte, 256)))
+	reqValid.Header.Set("X-Goog-Upload-Command", "upload")
+	reqValid.Header.Set("X-Goog-Upload-Offset", "0")
+	recValid := httptest.NewRecorder()
+	handler.ServeHTTP(recValid, reqValid)
+
+	if recValid.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on 256-byte aligned chunk upload, got %d", recValid.Code)
+	}
+
+	// Finalized chunk of arbitrary size should succeed
+	reqFinal := httptest.NewRequest("POST", u.String(), bytes.NewReader(make([]byte, 100)))
+	reqFinal.Header.Set("X-Goog-Upload-Command", "upload, finalize")
+	reqFinal.Header.Set("X-Goog-Upload-Offset", "256")
+	recFinal := httptest.NewRecorder()
+	handler.ServeHTTP(recFinal, reqFinal)
+
+	if recFinal.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on unaligned final chunk upload, got %d", recFinal.Code)
+	}
+}
+
+

--- a/server/resumableupload/resumableupload_test.go
+++ b/server/resumableupload/resumableupload_test.go
@@ -178,3 +178,52 @@ func TestQueryAndUploadAfterCancel(t *testing.T) {
 		t.Fatalf("expected 400 Bad Request on upload after cancel, got %d", recUpload.Code)
 	}
 }
+
+func TestNonFatalStartErrorWithClientUUID(t *testing.T) {
+	mgr := resumableupload.NewManager()
+	handler := mgr.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	cfgA := `{"client_uuid":"client-a","error_code":503,"failure_count":1}`
+
+	// 1st request for client-a fails with 503
+	reqA1 := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqA1.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqA1.Header.Set("X-Goog-Upload-Command", "start")
+	reqA1.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_start")
+	reqA1.Header.Set("X-Goog-Test-Scenario-Config", cfgA)
+	recA1 := httptest.NewRecorder()
+	handler.ServeHTTP(recA1, reqA1)
+
+	if recA1.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable on first start for client-a, got %d", recA1.Code)
+	}
+
+	// 2nd request for client-a succeeds (failure_count=1 exhausted)
+	reqA2 := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqA2.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqA2.Header.Set("X-Goog-Upload-Command", "start")
+	reqA2.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_start")
+	reqA2.Header.Set("X-Goog-Test-Scenario-Config", cfgA)
+	recA2 := httptest.NewRecorder()
+	handler.ServeHTTP(recA2, reqA2)
+
+	if recA2.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK on retry start for client-a, got %d", recA2.Code)
+	}
+
+	// Request for client-b fails independently with 503 despite same RemoteAddr
+	cfgB := `{"client_uuid":"client-b","error_code":503,"failure_count":1}`
+	reqB1 := httptest.NewRequest("POST", "http://localhost:7469/upload", nil)
+	reqB1.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	reqB1.Header.Set("X-Goog-Upload-Command", "start")
+	reqB1.Header.Set("X-Goog-Test-Scenario", "non_fatal_error_on_start")
+	reqB1.Header.Set("X-Goog-Test-Scenario-Config", cfgB)
+	recB1 := httptest.NewRecorder()
+	handler.ServeHTTP(recB1, reqB1)
+
+	if recB1.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 Service Unavailable on first start for client-b, got %d", recB1.Code)
+	}
+}


### PR DESCRIPTION
follow-up to #1657. Adds the following error scenarios to Resumable Uploads server

| Scenario Name | Description | Header Configuration | Expected Client Behavior |
| :--- | :--- | :--- | :--- |
| **`non_fatal_error_on_start`** | Returns a retriable HTTP error (`503 Service Unavailable` by default) on initial `start` command. | `X-Goog-Test-Scenario: non_fatal_error_on_start`<br/>`X-Goog-Test-Scenario-Config: {"error_code": 503, "failure_count": 1}` | Automatically retries initial `start` request and succeeds. |
| **`fatal_error_on_start`** | Returns a fatal HTTP error (`403 Forbidden` by default) on initial `start` command. | `X-Goog-Test-Scenario: fatal_error_on_start`<br/>`X-Goog-Test-Scenario-Config: {"error_code": 403}` | Aborts session and raises an error with status code `403`. |
| **`non_fatal_error_on_chunk_upload`** | Returns a retriable error (`503`) during chunk upload, triggering recovery query exchange. | `X-Goog-Test-Scenario: non_fatal_error_on_chunk_upload`<br/>`X-Goog-Test-Scenario-Config: {"error_code": 503, "failure_count": 1, "after_offset": 1024}` | Enters `RECOVERY` phase, queries committed offset (`X-Goog-Upload-Command: query`), and resumes uploading remaining bytes. |
| **`non_fatal_error_on_query`** | Returns a retriable error (`503`) on the recovery `query` command. | `X-Goog-Test-Scenario: non_fatal_error_on_query`<br/>`X-Goog-Test-Scenario-Config: {"error_code": 503, "failure_count": 1}` | Retries the `query` request until server returns `X-Goog-Upload-Size-Received`, then resumes transmission. |
| **`chunk_granularity`** | Returns `X-Goog-Upload-Chunk-Granularity: 256` on `start` and rejects non-final chunks whose length is not a multiple of `256`. | `X-Goog-Test-Scenario: chunk_granularity` | Parses granularity from `start` response and rounds chunk boundaries to multiples of `256` bytes. |