### PR TITLE
fix: fix HTTP 400 on resumable upload requests due to middleware execution order

### DIFF
--- a/cmd/gapic-showcase/endpoint.go
+++ b/cmd/gapic-showcase/endpoint.go
@@ -453,14 +453,14 @@ func newEndpointREST(lis net.Listener, backend *services.Backend) *endpointREST 
 	})
 	genrest.RegisterHandlers(router, backend)
 
-	// Register Resumable Upload protocol middleware
+	// Register Resumable Upload protocol and TLS HTTP middleware as outer HTTP handlers
 	resumableMgr := resumableupload.NewManager()
-	router.Use(resumableMgr.Middleware)
+	var handler http.Handler = router
+	handler = resumableMgr.Middleware(handler)
+	handler = server.TLSHTTPMiddleware(handler)
 
-	// Register TLS HTTP Middleware
-	router.Use(server.TLSHTTPMiddleware)
 	return &endpointREST{
-		server:   &http.Server{Handler: router},
+		server:   &http.Server{Handler: handler},
 		listener: lis,
 	}
 }

--- a/cmd/gapic-showcase/endpoint_test.go
+++ b/cmd/gapic-showcase/endpoint_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"io"
 	"log"
 	"net"
@@ -23,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/googleapis/gapic-showcase/server"
 	"github.com/googleapis/gapic-showcase/util/genrest/resttools"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -236,4 +238,31 @@ func allowFullJSON() *resttools.JSONMarshalOptions {
 func noSpace(src string) string {
 	str := strings.ReplaceAll(src, "\n", "")
 	return strings.ReplaceAll(str, " ", "")
+}
+
+// TestResumableUploadMiddlewareOrder verifies that outer middleware (such as TLS HTTP middleware)
+// executes on Resumable Upload protocol requests.
+func TestResumableUploadMiddlewareOrder(t *testing.T) {
+	backend := createBackends()
+	restServer := newEndpointREST(net.Listener(nil), backend)
+
+	// Record TLS handshake state for the client address
+	server.RecordTLSHandshake("192.0.2.1:1234", tls.ConnectionState{CurveID: tls.X25519}, []tls.CurveID{tls.X25519})
+	defer server.RemoveTLSState("192.0.2.1:1234")
+
+	req := httptest.NewRequest("POST", "/resumable/upload/v1beta1/files:upload", strings.NewReader(`{"name":"sample.txt"}`))
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	req.Header.Set("X-Goog-Upload-Command", "start")
+	rec := httptest.NewRecorder()
+
+	restServer.server.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got, want := rec.Header().Get("x-showcase-tls-group"), "X25519"; got != want {
+		t.Fatalf("expected TLS group %s, got %s", want, got)
+	}
 }

--- a/server/resumableupload/resumableupload_test.go
+++ b/server/resumableupload/resumableupload_test.go
@@ -449,5 +449,3 @@ func TestChunkGranularityScenario(t *testing.T) {
 		t.Fatalf("expected 200 OK on unaligned final chunk upload, got %d", recFinal.Code)
 	}
 }
-
-


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-showcase/issues/1664

I encountered HTTP 400 errors while testing resumable uploads which was added in https://github.com/googleapis/gapic-showcase/pull/1657. I worked with Gemini offline on this fix