### PR TITLE
refactor: remove --enable-pqc flag in favor of --tls-groups

### DIFF
--- a/TLS_GUIDE.md
+++ b/TLS_GUIDE.md
@@ -71,17 +71,6 @@ Provide the server cert, key, **and the CA cert** (which the server will use to 
 
 When running on **Go 1.24+**, the hybrid post-quantum key exchange **`X25519MLKEM768`** is enabled by default on the Showcase server.
 
-### Disabling PQC (Server-Side)
-
-If you need to verify classical fallback behavior, you can force the Showcase server to disable all Post-Quantum hybrid key exchanges and use only classical cryptography by starting the server with the `--enable-pqc=false` flag:
-
-```sh
-./gapic-showcase run \
-  --tls-cert certs/server.crt \
-  --tls-key certs/server.key \
-  --enable-pqc=false
-```
-
 ### Restricting / Pinning Allowed TLS Groups (`--tls-groups`)
 
 To strictly test whether a client supports a specific key exchange algorithm (or to test custom server preference ordering), use the `--tls-groups` flag.
@@ -100,6 +89,18 @@ The flag accepts a comma-separated list of standard [IANA Key Exchange Group IDs
   --tls-cert certs/server.crt \
   --tls-key certs/server.key \
   --tls-groups 0x001d,0x0017
+```
+
+### Disabling PQC (Classical Only)
+
+To disable Post-Quantum hybrid key exchanges and restrict the Showcase server to classical cryptography only, specify the classical curves using `--tls-groups`:
+
+```sh
+# Restrict server to classical curves (X25519, P-256, P-384, P-521):
+./gapic-showcase run \
+  --tls-cert certs/server.crt \
+  --tls-key certs/server.key \
+  --tls-groups 0x001d,0x0017,0x0018,0x0019
 ```
 
 #### Common IANA Group IDs Reference

--- a/cmd/gapic-showcase/endpoint.go
+++ b/cmd/gapic-showcase/endpoint.go
@@ -52,7 +52,6 @@ type RuntimeConfig struct {
 	tlsCert      string
 	tlsKey       string
 	tlsGroups    string
-	enablePQC    *bool
 	autoTLS      bool
 	caCertFile   string
 }
@@ -114,11 +113,6 @@ func createTLSConfig(config RuntimeConfig) *tls.Config {
 		NextProtos:   []string{"h2", "http/1.1"},
 	}
 
-	pqcEnabled := true
-	if config.enablePQC != nil {
-		pqcEnabled = *config.enablePQC
-	}
-
 	if config.tlsGroups != "" {
 		groups, err := server.ParseTLSGroups(config.tlsGroups)
 		if err != nil {
@@ -130,14 +124,6 @@ func createTLSConfig(config RuntimeConfig) *tls.Config {
 			groupNames = append(groupNames, g.String())
 		}
 		stdLog.Printf("Restricted server TLS key exchange groups: %s", strings.Join(groupNames, ","))
-	} else if !pqcEnabled {
-		baseConfig.CurvePreferences = []tls.CurveID{
-			tls.X25519,
-			tls.CurveP256,
-			tls.CurveP384,
-			tls.CurveP521,
-		}
-		stdLog.Printf("PQC key exchanges disabled on server. Using classical curves only.")
 	}
 
 	// Handle Client CA for mTLS / One-Way TLS

--- a/cmd/gapic-showcase/run.go
+++ b/cmd/gapic-showcase/run.go
@@ -31,12 +31,10 @@ func message(err error) string {
 
 func init() {
 	config := RuntimeConfig{}
-	var enablePQCVal bool
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Runs the showcase server",
 		Run: func(cmd *cobra.Command, args []string) {
-			config.enablePQC = &enablePQCVal
 			cmuxServer := CreateAllEndpoints(config)
 
 			done := make(chan os.Signal, 2)
@@ -100,11 +98,6 @@ func init() {
 		"mtls-key",
 		"",
 		"The server private key path for custom mutual TLS channel. (Deprecated: use tls-key)")
-	runCmd.Flags().BoolVar(
-		&enablePQCVal,
-		"enable-pqc",
-		true,
-		"Enable Post-Quantum Cryptography (PQC) hybrid key exchanges.")
 	runCmd.Flags().StringVar(
 		&config.tlsGroups,
 		"tls-groups",

--- a/cmd/gapic-showcase/tls_test.go
+++ b/cmd/gapic-showcase/tls_test.go
@@ -37,11 +37,11 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func setupTLSTestServer(t *testing.T, enablePQC *bool) (addr string, certPool *x509.CertPool, cleanup func()) {
-	return setupTLSTestServerWithGroups(t, enablePQC, "")
+func setupTLSTestServer(t *testing.T) (addr string, certPool *x509.CertPool, cleanup func()) {
+	return setupTLSTestServerWithGroups(t, "")
 }
 
-func setupTLSTestServerWithGroups(t *testing.T, enablePQC *bool, tlsGroups string) (addr string, certPool *x509.CertPool, cleanup func()) {
+func setupTLSTestServerWithGroups(t *testing.T, tlsGroups string) (addr string, certPool *x509.CertPool, cleanup func()) {
 	t.Helper()
 	caPath := filepath.Join(t.TempDir(), "ca.crt")
 	config := RuntimeConfig{
@@ -49,7 +49,6 @@ func setupTLSTestServerWithGroups(t *testing.T, enablePQC *bool, tlsGroups strin
 		fallbackPort: ":0", // avoid conflicts
 		autoTLS:      true,
 		caCertFile:   caPath,
-		enablePQC:    enablePQC,
 		tlsGroups:    tlsGroups,
 	}
 
@@ -80,7 +79,7 @@ func setupTLSTestServerWithGroups(t *testing.T, enablePQC *bool, tlsGroups strin
 
 func TestConnectWithTLS(t *testing.T) {
 	t.Parallel()
-	addr, certPool, cleanup := setupTLSTestServer(t, nil)
+	addr, certPool, cleanup := setupTLSTestServer(t)
 	defer cleanup()
 
 	creds := credentials.NewTLS(&tls.Config{
@@ -136,7 +135,7 @@ func TestConnectWithTLS(t *testing.T) {
 
 func TestConnectWithTLS_REST(t *testing.T) {
 	t.Parallel()
-	addr, certPool, cleanup := setupTLSTestServer(t, nil)
+	addr, certPool, cleanup := setupTLSTestServer(t)
 	defer cleanup()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -199,7 +198,7 @@ func assertHeader(t *testing.T, md metadata.MD, key, expected string) {
 
 func TestConnectWithTLS_PQCDisabled(t *testing.T) {
 	t.Parallel()
-	addr, certPool, cleanup := setupTLSTestServer(t, boolPtr(false))
+	addr, certPool, cleanup := setupTLSTestServerWithGroups(t, "0x001d,0x0017,0x0018,0x0019")
 	defer cleanup()
 
 	creds := credentials.NewTLS(&tls.Config{
@@ -243,10 +242,6 @@ func TestConnectWithTLS_PQCDisabled(t *testing.T) {
 	assertHeader(t, header, "x-showcase-tls-group", "X25519")
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 type headerCapturer struct {
 	transport http.RoundTripper
 	headers   http.Header
@@ -276,7 +271,7 @@ func assertRESTHeader(t *testing.T, headers http.Header, key, expected string) {
 func TestConnectWithTLS_GroupPinned(t *testing.T) {
 	t.Parallel()
 	// Pin server to X25519MLKEM768 (0x11ec)
-	addr, certPool, cleanup := setupTLSTestServerWithGroups(t, nil, "0x11ec")
+	addr, certPool, cleanup := setupTLSTestServerWithGroups(t, "0x11ec")
 	defer cleanup()
 
 	creds := credentials.NewTLS(&tls.Config{
@@ -315,7 +310,7 @@ func TestConnectWithTLS_GroupPinned(t *testing.T) {
 func TestConnectWithTLS_GroupMismatch_FailsHandshake(t *testing.T) {
 	t.Parallel()
 	// Server only allows X25519MLKEM768 (0x11ec)
-	addr, certPool, cleanup := setupTLSTestServerWithGroups(t, nil, "0x11ec")
+	addr, certPool, cleanup := setupTLSTestServerWithGroups(t, "0x11ec")
 	defer cleanup()
 
 	// Client only offers classical X25519


### PR DESCRIPTION
The --tls-groups flag provides more precise control over key-exchange algorithms and eliminates duplicate functionality. To achieve the same classical-only behavior previously provided by --enable-pqc=false, users can pass the classical curve IDs using --tls-groups=0x001d,0x0017,0x0018,0x0019 (or 29,23,24,25 in decimal).

The TLS guide documentation and integration tests have been updated accordingly.

